### PR TITLE
feat: discover tool targets + skills-first docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,33 @@ Recommended approach:
 export ICA_HOME="$HOME/.ica"
 ```
 
+## Discovery And Multi-Target Install (Local)
+
+Best-effort detection will look for common agent home directories and/or binaries.
+
+- macOS/Linux:
+  - `make discover-targets`
+  - `make install-discovered` (installs into every discovered target)
+- Windows:
+  - `.\install.ps1 discover`
+  - `.\install.ps1 install-discovered`
+
+Override discovery if needed:
+
+- `ICA_DISCOVER_TARGETS=claude,codex` (explicit list)
+- `ICA_DISCOVER_ALL=1` (all supported targets)
+
+## Project-Only Install
+
+To install ICA into a single repository (and not into your user agent home), use a project path:
+
+- macOS/Linux:
+  - `make install-project PROJECT_PATH=/path/to/project AGENT=codex`
+  - You can combine with discovery: `make install-discovered PROJECT_PATH=/path/to/project`
+- Windows:
+  - `.\install.ps1 install -ProjectPath C:\MyProject -Agent codex`
+  - `.\install.ps1 install-discovered -ProjectPath C:\MyProject`
+
 ## Where Files Live
 
 Installed files (within the agent home):
@@ -60,4 +87,3 @@ Project files (inside repositories using ICA):
 
 - `.agent/queue/` (created/managed by `work-queue`)
 - `summaries/`, `memory/`, `stories/`, `bugs/` (used by skills for file placement conventions)
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ ICA installs into a tool-specific "agent home" directory:
 - Codex: `~/.codex` (default)
 - Cursor / Gemini CLI / Antigravity: supported via `AGENT_DIR_NAME` mapping, plus `AGENTS.md` guidance (tool-specific wiring varies).
 
+Best-effort discovery (local):
+
+- macOS/Linux: `make discover-targets` and `make install-discovered`
+- Windows: `.\install.ps1 discover` and `.\install.ps1 install-discovered`
+
+Override discovery if needed:
+
+- `ICA_DISCOVER_TARGETS=claude,codex` (explicit list)
+- `ICA_DISCOVER_ALL=1` (all supported targets)
+
 Set `ICA_HOME` to your chosen agent home directory if you run ICA scripts/hooks outside Claude Code:
 
 ```bash
@@ -33,6 +43,9 @@ cd intelligent-code-agents
 
 make install AGENT=claude   # installs into ~/.claude
 make install AGENT=codex    # installs into ~/.codex
+
+# Project-only install (installs into /path/to/project/<agent_home_dir>)
+make install-project PROJECT_PATH=/path/to/project AGENT=codex
 ```
 
 Windows (PowerShell):
@@ -43,6 +56,13 @@ cd intelligent-code-agents
 
 .\install.ps1 install -Agent claude
 .\install.ps1 install -Agent codex
+
+# Best-effort discovery
+.\install.ps1 discover
+.\install.ps1 install-discovered
+
+# Project-only install
+.\install.ps1 install -ProjectPath C:\MyProject -Agent codex
 ```
 
 Override the agent home directory name (advanced):
@@ -53,20 +73,13 @@ make install AGENT=custom AGENT_DIR_NAME=.my-agent-home
 
 ## Using ICA
 
-If your client supports `@Role` mentions (for example Claude Code):
+Use skills by name and keep prompts explicit about the intent and output.
 
 ```text
-@PM break down the story
-@Architect review the design
-@Developer implement auth
-@Reviewer audit for regressions
-```
-
-If your client does not support role mentions, use the same intent in plain language:
-
-```text
-As PM: break down the story into work items in .agent/queue/
-As Reviewer: run a regression review and post an ICA-REVIEW-RECEIPT
+pm: break down the story into work items in .agent/queue/
+architect: review the approach and call out risks/tradeoffs
+developer: implement the change
+reviewer: audit for regressions and post an ICA-REVIEW-RECEIPT
 ```
 
 ## Workflow Gate (PRs)
@@ -101,4 +114,3 @@ Reference defaults are shipped as:
 ## License
 
 MIT (see `LICENSE`)
-

--- a/ansible/roles/intelligent_code_agents/tasks/main.yml
+++ b/ansible/roles/intelligent_code_agents/tasks/main.yml
@@ -406,4 +406,4 @@
       - "🎯 Skills: 35 cross-platform skills (roles, commands, workflows, memory)"
       - "🤖 Virtual Team: 14 core roles + unlimited specialists"
       - "🔒 Behavioral Hooks: PreToolUse (infra protection, summaries)"
-      - "🚀 Use @Role or /skill-name to activate capabilities"
+      - "🚀 Use role skills by name (pm, architect, developer, reviewer, etc.) or /skill-name (if supported) to activate capabilities"

--- a/best-practices/release-workflow-automation.md
+++ b/best-practices/release-workflow-automation.md
@@ -89,14 +89,14 @@ Usage: `make release`
 Create `.claude/commands/release.md`:
 
 ```markdown
-You are @PM coordinating a release.
+You are pm coordinating a release.
 
 ## Task
 Execute the release workflow for the current PR.
 
 ## Steps
 1. Validate PR is approved and checks pass
-2. Create AgentTask for @DevOps-Engineer:
+2. Create AgentTask for devops-engineer:
    - Merge PR with squash strategy
    - Create and push annotated tag
    - Generate GitHub release from changelog
@@ -109,9 +109,9 @@ Usage: `/release` in Claude Code
 
 ### Option 4: Natural Language (Recommended)
 
-Just ask: `@PM merge and release`
+Just ask: `pm merge and release`
 
-PM creates AgentTask for @DevOps-Engineer who executes the workflow.
+PM creates AgentTask for devops-engineer who executes the workflow.
 
 ## Design Principles
 
@@ -120,8 +120,8 @@ Release workflows defined in configuration files, not hardcoded logic. Projects 
 
 ### 2. Explicit Trigger Required
 **NEVER automatic** - all releases require explicit trigger:
-- User command: `@PM merge and release`
-- Natural language: `@DevOps-Engineer execute release pipeline`
+- User command: `pm merge and release`
+- Natural language: `devops-engineer execute release pipeline`
 - Workflow command: `/ica-release`
 
 ### 3. Flexibility for Project Types
@@ -232,7 +232,7 @@ Create a project-specific release command:
 ```markdown
 # .claude/commands/release.md
 
-You are @PM coordinating a software release.
+You are pm coordinating a software release.
 
 ## Context
 - **Project**: {project_name}
@@ -245,28 +245,28 @@ Execute the complete release workflow for the current PR.
 ## Workflow Steps
 
 ### 1. Pre-Release Validation
-Create AgentTask for @QA-Engineer:
+Create AgentTask for qa-engineer:
 - Verify PR is approved
 - Confirm all CI checks passing
 - Validate version bumped correctly
 - Check CHANGELOG.md updated
 
 ### 2. Merge and Tag
-Create AgentTask for @DevOps-Engineer:
+Create AgentTask for devops-engineer:
 - Merge PR using squash strategy
 - Create annotated tag: v{version}
 - Push tag to remote repository
 - Delete feature branch
 
 ### 3. GitHub Release
-Create AgentTask for @DevOps-Engineer:
+Create AgentTask for devops-engineer:
 - Extract changelog section for version
 - Create GitHub release with changelog
 - Attach any release artifacts
 - Verify release published
 
 ### 4. Post-Release
-Create AgentTask for @PM:
+Create AgentTask for pm:
 - Update project documentation
 - Notify team of release
 - Close related issues
@@ -288,19 +288,19 @@ The most flexible approach uses natural language with the virtual team:
 
 ```bash
 # Simple release
-@PM merge and release
+pm merge and release
 
 # With specific PR
-@PM merge PR #42 and create release
+pm merge PR #42 and create release
 
 # Draft release for review
-@PM create draft release for current PR
+pm create draft release for current PR
 
 # Specific workflow steps
-@DevOps-Engineer merge PR, create tag, and publish release
+devops-engineer merge PR, create tag, and publish release
 ```
 
-PM analyzes the request, creates appropriate AgentTasks for @DevOps-Engineer, and orchestrates the complete workflow.
+PM analyzes the request, creates appropriate AgentTasks for devops-engineer, and orchestrates the complete workflow.
 
 ## Usage Examples
 
@@ -337,29 +337,29 @@ make help
 
 ```bash
 # Simple release trigger
-@PM merge and release
+pm merge and release
 
 # Specific PR
-@PM merge PR #42 and create release
+pm merge PR #42 and create release
 
 # Draft release for review
-@PM create draft release for current PR
+pm create draft release for current PR
 
 # Direct assignment
-@DevOps-Engineer execute release pipeline
+devops-engineer execute release pipeline
 ```
 
 ## How It Works
 
 ### AgentTask-Based Execution
 
-When you request a release, PM creates an AgentTask for @DevOps-Engineer:
+When you request a release, PM creates an AgentTask for devops-engineer:
 
 ```markdown
 ## AgentTask Context
 **Type**: Release Pipeline Execution
-**Agent**: @DevOps-Engineer
-**Trigger**: User request "@PM merge and release"
+**Agent**: devops-engineer
+**Trigger**: User request "pm merge and release"
 
 ## Pipeline Steps
 1. Validation (PR approved, checks passing)
@@ -373,7 +373,7 @@ The project provides release automation via:
 - Shell script: scripts/release.sh
 - Make target: make release
 - Custom command: /release
-- Or natural language: "@PM merge and release"
+- Or natural language: "pm merge and release"
 
 ## Success Criteria
 - PR merged to default branch
@@ -718,7 +718,7 @@ Every release pipeline execution logged with:
 ```json
 {
   "timestamp": "2025-10-12T14:30:00Z",
-  "trigger": "@PM merge and release",
+  "trigger": "pm merge and release",
   "pr_number": 42,
   "configuration": {
     "merge_strategy": "squash",
@@ -754,16 +754,16 @@ TAG_FORMAT="v{version}"
 **Execution:**
 ```bash
 # 1. User request
-@PM merge PR #45 and release patch
+pm merge PR #45 and release patch
 
-# 2. PM creates AgentTask for @DevOps-Engineer
+# 2. PM creates AgentTask for devops-engineer
 
-# 3. @DevOps-Engineer validates
+# 3. devops-engineer validates
 - PR #45 approved ✓
 - Checks passing ✓
 - Version bumped: 8.18.9 → 8.18.10 ✓
 
-# 4. @DevOps-Engineer executes scripts/release.sh
+# 4. devops-engineer executes scripts/release.sh
 - Merge: squash merge to main ✓
 - Tag: v8.18.10 created and pushed ✓
 - Release: GitHub release with changelog ✓
@@ -788,17 +788,17 @@ release:
 **Execution:**
 ```bash
 # 1. User request
-@PM merge and release feature/user-auth
+pm merge and release feature/user-auth
 
-# 2. PM creates AgentTask for @DevOps-Engineer
+# 2. PM creates AgentTask for devops-engineer
 
-# 3. @DevOps-Engineer validates
+# 3. devops-engineer validates
 - PR #42 approved ✓
 - All checks passing ✓
 - Version bumped: 8.18.10 → 8.19.0 ✓
 - CHANGELOG updated ✓
 
-# 4. @DevOps-Engineer runs: make release
+# 4. devops-engineer runs: make release
 - Merge: squash merge to main ✓
 - Tag: v8.19.0 created and pushed ✓
 - Release: Changelog notes extracted ✓
@@ -819,9 +819,9 @@ Documentation updates don't trigger releases.
 **Execution:**
 ```bash
 # 1. Direct commit to main
-@Developer update README with new installation steps
+developer update README with new installation steps
 
-# 2. @Developer commits directly
+# 2. developer commits directly
 git add README.md
 git commit -m "docs: update installation instructions"
 git push origin main
@@ -938,16 +938,16 @@ echo "🚀 Pre-release v${VERSION} deployed"
 Release automation integrates with the virtual team system:
 
 **Work Classification:**
-- **Simple Releases**: @DevOps-Engineer executes directly via scripts/release.sh
-- **Complex Releases**: @PM coordinates multi-step workflow
+- **Simple Releases**: devops-engineer executes directly via scripts/release.sh
+- **Complex Releases**: pm coordinates multi-step workflow
 - **Emergency Hotfixes**: Fast-track with minimal gates
 - **Major Releases**: Full coordination with breaking change assessment
 
 **Role Responsibilities:**
-- **@PM**: Orchestrates release process, validates readiness
-- **@DevOps-Engineer**: Executes release scripts, handles git operations
-- **@QA-Engineer**: Validates release readiness, confirms tests pass
-- **@Architect**: Reviews breaking changes for major releases
+- **pm**: Orchestrates release process, validates readiness
+- **devops-engineer**: Executes release scripts, handles git operations
+- **qa-engineer**: Validates release readiness, confirms tests pass
+- **architect**: Reviews breaking changes for major releases
 
 ### Git Privacy Integration
 
@@ -1055,7 +1055,7 @@ Comprehensive audit trail in releases.log
 Clear README section explaining release process
 
 ✅ **Use Natural Language**
-`@PM merge and release` is clearer than commands
+`pm merge and release` is clearer than commands
 
 ### DON'T
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,14 +6,14 @@ Terminology can be confusing because different tools use different words.
 
 ICA primarily ships **Skills**:
 - source of truth: `src/skills/*/SKILL.md`
-- installed to: `~/.claude/skills/` (and optionally project `.claude/skills/`)
+- installed to: your agent home `skills/` directory (for example `$ICA_HOME/skills/`)
 
-Role names like `@PM` or `@Reviewer` are **role skills** with well-defined responsibilities.
+Role skills like `pm` or `reviewer` are skills with well-defined responsibilities.
 
 ## How “Agents” Happen
 
 - In **Claude Code**, the UI/runtime can run specialized subagents. ICA’s role skills are designed to be invoked with
-  role mentions like `@PM ...` or `@Reviewer ...`.
+  explicit role skill selection and a dedicated sub-agent for review gates when needed.
 - In other tools, you can still use the same intent in plain language (skills are loaded by description matching).
 
 ## Related Files
@@ -21,4 +21,3 @@ Role names like `@PM` or `@Reviewer` are **role skills** with well-defined respo
 - Behaviors (always-on structural guidance): `src/behaviors/`
 - Hooks (Claude Code safety + file hygiene): `src/hooks/`
 - Work queue (cross-platform persistence): `.agent/queue/`
-

--- a/docs/agenttask-system-guide.md
+++ b/docs/agenttask-system-guide.md
@@ -21,11 +21,11 @@ The **AgentTask** system replaces complex multi-step workflows with self-contain
 ## How It Works
 
 ### 1. Work Request
-User requests work through natural language or @Role mention:
+User requests work through natural language or by explicitly selecting a role skill:
 ```
 "Build user authentication"
 # OR
-"@Developer implement OAuth2 login"
+"developer implement OAuth2 login"
 ```
 
 ### 2. Complexity Analysis
@@ -65,7 +65,7 @@ The system automatically discovers and injects relevant methodological approache
 
 ### 5. Agent System Execution
 AgentTasks execute through the 14-role virtual team system:
-- **Direct @Agent Communication**: Natural @Role mentions trigger Task tool subagent creation
+- **Role skill execution**: Explicit role skill selection can trigger sub-agent execution (tool-dependent)
 - **Context Preservation**: Complete AgentTask context passed to executing subagent
 - **Behavioral Patterns**: Embedded behavioral patterns guide specialist execution
 - **Dynamic Specialist Creation**: Unlimited specialists created when technology expertise needed
@@ -157,13 +157,13 @@ agenttask_configuration:
 
 ## Essential Skills
 
-Note: The system provides 3 essential skills for system operations. Most interaction is through @Role communication:
+Note: The system provides 3 essential skills for system operations. Most interaction is through role skills:
 
 - **ica-init-system** - Initialize virtual team system
 - **ica-get-setting** - Get configuration values
 - **ica-search-memory** - Search learning patterns
 
-Primary interaction: @Role communication (@PM, @Developer, @AI-Engineer, etc.)
+Primary interaction: role skills (pm, developer, ai-engineer, etc.)
 
 ## Example
 
@@ -177,7 +177,7 @@ Primary interaction: @Role communication (@PM, @Developer, @AI-Engineer, etc.)
 - Existing middleware patterns
 - Rate limiting best practices
 - Executable tests
-- Everything @Developer needs
+- Everything the developer role needs
 
 # Specialist executes autonomously
 # Work completes in single pass

--- a/docs/agenttask-templates-guide.md
+++ b/docs/agenttask-templates-guide.md
@@ -123,7 +123,7 @@ validation:
 - Code pattern references with existing implementations
 - Pre-assigned SME reviewer through agent system
 - Complete context embedding with no runtime config lookups
-- Direct @Agent execution through Task tool subagent creation
+- Direct sub-agent execution through your Task/sub-agent mechanism
 
 **Structure includes:**
 - Full context with project settings
@@ -401,14 +401,14 @@ agenttask_configuration:
 Different roles can have different AgentTask structures:
 
 ```yaml
-# For @Security-Engineer
+# For security-engineer
 security_prb_overrides:
   always_include:
     - threat_model
     - vulnerability_assessment
     - compliance_check
     
-# For @AI-Engineer  
+# For ai-engineer
 ai_prb_overrides:
   always_include:
     - model_selection
@@ -502,12 +502,12 @@ agenttask_configuration:
 All AgentTask templates now integrate with the 14-role virtual team system:
 
 **Core Roles Available:**
-- @PM, @Architect, @Developer, @System-Engineer, @DevOps-Engineer
-- @Database-Engineer, @Security-Engineer, @AI-Engineer, @Web-Designer
-- @QA-Engineer, @Backend-Tester, @Requirements-Engineer, @User-Role
+- pm, architect, developer, system-engineer, devops-engineer
+- database-engineer, security-engineer, ai-engineer, web-designer
+- qa-engineer, backend-tester, requirements-engineer, user-tester
 
 **Dynamic Specialist Creation:**
-- **Unlimited Technology Coverage**: ANY domain (@React-Developer, @AWS-Engineer, @Kubernetes-DevOps-Engineer)
+- **Unlimited Technology Coverage**: ANY domain (react-developer, aws-engineer, kubernetes-devops-engineer)
 - **Technology-Driven Creation**: ALWAYS when technology expertise needed for optimal execution  
 - **PM + Architect Collaboration**: Dynamic specialists created through behavioral patterns
 - **Storage Location**: Specialists are created dynamically via AgentTask context (no separate files)
@@ -523,12 +523,12 @@ specialization_context:
   role_assignment: "PM + Specialist Architect determine when specialists should be created"
 ```
 
-### Execution Through @Agent Communication
+### Execution Through Role Skills
 
 **Natural Communication Pattern:**
-- User: "@Developer implement authentication API"
+- User: "developer implement authentication API"
 - System: Creates Medium AgentTask with embedded context
-- Task tool: Creates @Developer subagent with complete AgentTask context
+- Task tool: Creates a developer subagent with complete AgentTask context
 - Subagent: Executes 9-step process autonomously
 - Result: Complete implementation with learning capture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,8 @@ Intelligent Code Agents is a CC-native framework that adds role-based specialist
 ### Skills (34 total)
 Skills are the primary interface for specialized capabilities. They are:
 - Defined in `src/skills/*/SKILL.md`
-- Installed to `.claude/skills/`
-- Invoked via skill description matching or `@Role` patterns
+- Installed to your agent home `skills/` directory (for example `$ICA_HOME/skills/`)
+- Invoked via explicit skill names and/or description matching (tool-dependent)
 
 **Categories:**
 - **Role Skills (14):** pm, architect, developer, system-engineer, devops-engineer, database-engineer, security-engineer, ai-engineer, web-designer, qa-engineer, backend-tester, requirements-engineer, user-tester, reviewer

--- a/docs/execution-flow-diagram.md
+++ b/docs/execution-flow-diagram.md
@@ -14,9 +14,9 @@ MAIN AGENT (coordination)
   |
   v
 ROLE EXECUTION (specialists)
-  - @Developer implements
-  - @Reviewer audits and fixes issues
-  - @DevOps-Engineer handles release mechanics (when requested)
+  - developer implements
+  - reviewer audits and fixes issues
+  - devops-engineer handles release mechanics (when requested)
   |
   v
 QUALITY GATES
@@ -46,4 +46,3 @@ RELEASE PHASE (only when requested)
 See:
 - `docs/workflow-guide.md`
 - `docs/configuration-guide.md`
-

--- a/docs/project-configuration.md
+++ b/docs/project-configuration.md
@@ -138,8 +138,8 @@ echo "User Authentication Requirements..." > drafts/new-feature/requirements.md
 ```
 
 The system will:
-1. @PM analyzes requirements
-2. @Architect designs approach
+1. pm analyzes requirements
+2. architect designs approach
 3. Generate appropriate AgentTasks with all project context
 4. Include best practices and standards
 5. Reference existing code patterns

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -3,20 +3,18 @@
 ICA is **skills-first**: the system loads `SKILL.md` instructions on demand based on:
 - explicit skill names (e.g. “use `reviewer`”)
 - description matching (you ask for a review, it pulls `reviewer`)
-- role mentions (when supported)
+- role skills (pm, architect, developer, reviewer, etc.)
 
-## Role Invocation (Still The Recommended Path)
-
-If your client supports role mentions (Claude Code), this is the primary interaction style:
+## Skill Invocation (Recommended)
 
 ```text
-@PM break down the story into work items
-@Architect review the approach
-@Developer implement the change
-@Reviewer run a regression review
+pm break down the story into work items
+architect review the approach
+developer implement the change
+reviewer run a regression review
 ```
 
-If your client does not support `@Role`, use the same intent in plain language:
+Use the same intent in plain language if your client does not have explicit skill invocation syntax:
 
 ```text
 As PM: break down the story into .agent/queue work items
@@ -60,4 +58,3 @@ file-placement, branch-protection, infrastructure-protection
 - `ica.workflow.json`: workflow automation controls (auto-merge standing approval, optional GitHub approvals gate, release automation)
 
 See `docs/configuration-guide.md` for the full hierarchy.
-

--- a/docs/template-extensions.md
+++ b/docs/template-extensions.md
@@ -574,7 +574,7 @@ Generate a test AgentTask to verify extensions work correctly:
 
 ```bash
 # Test with a medium complexity task
-@Developer implement a test feature
+developer implement a test feature
 ```
 
 ### Step 4: Remove Custom Templates

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,7 +117,7 @@ make install TARGET_PATH=./test-install 2>&1 | tee install.log
 
 ### Virtual Team System Not Responding
 
-**Symptoms:** No response to @Role commands
+**Symptoms:** No response to role skill commands
 
 **Cause:** System not properly initialized after installation.
 
@@ -135,7 +135,7 @@ grep "@~/.claude/modes/virtual-team.md" CLAUDE.md
 
 ### Role Commands Not Working
 
-**Symptoms:** @PM, @Developer commands ignored
+**Symptoms:** pm, developer commands ignored
 
 **Diagnosis:**
 1. Check if virtual team mode is loaded:
@@ -205,14 +205,14 @@ python -c "import yaml; yaml.safe_load(open('config.md').read())"
 grep -A 5 "system_nature:" CLAUDE.md
 
 # For AI-AGENTIC systems, use:
-@AI-Engineer    # For behavioral patterns, memory, AgentTasks
-@PM             # For story breakdown
-@Architect      # For system design
+ai-engineer    # For behavioral patterns, memory, AgentTasks
+pm             # For story breakdown
+architect      # For system design
 
 # For CODE-BASED systems, use:
-@Developer      # For implementation
-@Backend-Tester # For testing
-@DevOps-Engineer # For deployment
+developer      # For implementation
+backend-tester # For testing
+devops-engineer # For deployment
 ```
 
 ### Dynamic Specialist Creation Failed
@@ -228,20 +228,20 @@ grep -A 5 "system_nature:" CLAUDE.md
 1. Use valid domain patterns:
 ```bash
 # Valid patterns
-@React-Developer
-@AWS-Engineer
-@Database-Architect
-@Security-Specialist
+react-developer
+aws-engineer
+database-architect
+security-specialist
 
 # Invalid patterns (too generic)
-@Developer-Person
-@Generic-Specialist
+developer-Person
+generic-specialist
 ```
 
 2. Let PM + Architect create specialists:
 ```bash
-@PM Create specialist for React development
-# System will create @React-Developer automatically
+pm Create specialist for React development
+# System will create react-developer automatically
 ```
 
 ### Role Assignment Matrix Conflicts
@@ -256,7 +256,7 @@ grep -A 5 "system_nature:" CLAUDE.md
 **Solution:**
 Use PM + Architect collaboration:
 ```bash
-@PM analyze work type and assign appropriate specialist
+pm analyze work type and assign appropriate specialist
 # System will:
 # 1. Analyze project scope (AI-AGENTIC vs CODE-BASED)
 # 2. Analyze work type (implementation, security, etc.)
@@ -306,7 +306,7 @@ make clean-install
 ```bash
 # Wrong - subagent cannot resolve placeholders
 # Right - use main agent
-@PM Create AgentTask for this work request
+pm Create AgentTask for this work request
 ```
 
 2. Check configuration hierarchy:
@@ -326,7 +326,7 @@ make clean-install
 
 **Solution:**
 ```bash
-@PM break down this large story into multiple AgentTasks
+pm break down this large story into multiple AgentTasks
 # Each AgentTask will be <15 points
 # Sequential: STORY-001-AgentTask-001, STORY-001-AgentTask-002, etc.
 ```
@@ -696,7 +696,7 @@ max_concurrent_subagents: 2  # Reduce from default 5
 2. **Optimize Complex AgentTasks:**
 ```bash
 # Break down large AgentTasks (<15 complexity points)
-@PM break down this complex work into smaller AgentTasks
+pm break down this complex work into smaller AgentTasks
 ```
 
 ## Debug Techniques
@@ -881,7 +881,7 @@ When encountering issues:
 - [ ] Verify installation: `ls -la ~/.claude/`
 - [ ] Validate configuration: `/ica-load-config`
 - [ ] Check memory system: `/ica-memory-status`
-- [ ] Test basic commands: `@PM help`
+- [ ] Test basic commands: `pm help`
 - [ ] Review recent changes: `git log -5 --oneline`
 - [ ] Check file permissions: `ls -la`
 - [ ] Verify network connectivity (for remote operations)

--- a/docs/virtual-team-guide.md
+++ b/docs/virtual-team-guide.md
@@ -10,16 +10,14 @@ ICA turns a single agent session into a **role-based virtual team** via Skills.
 
 ## How To Involve Roles
 
-If your client supports it (Claude Code), use role mentions:
-
 ```text
-@PM break down this story into work items
-@Architect review the design
-@Developer implement the change
-@Reviewer check for regressions
+pm break down this story into work items
+architect review the design
+developer implement the change
+reviewer check for regressions
 ```
 
-If your client does not support `@Role`, use plain language:
+Use plain language if your client does not have explicit skill invocation syntax:
 
 ```text
 As PM: break this story into .agent/queue work items
@@ -29,34 +27,33 @@ As Reviewer: do a post-PR Stage 3 review and post an ICA-REVIEW-RECEIPT
 ## The 14 Core Roles
 
 Leadership and planning:
-- `@PM`: breakdown, sequencing, dependency management (does not implement)
-- `@Architect`: design, tradeoffs, consistency checks
+- `pm`: breakdown, sequencing, dependency management (does not implement)
+- `architect`: design, tradeoffs, consistency checks
 
 Implementation and operations:
-- `@Developer`, `@System-Engineer`, `@DevOps-Engineer`, `@Database-Engineer`
+- `developer`, `system-engineer`, `devops-engineer`, `database-engineer`
 
 Quality and risk:
-- `@QA-Engineer`, `@Backend-Tester`, `@User-Role`, `@Security-Engineer`, `@Reviewer`
+- `qa-engineer`, `backend-tester`, `user-tester`, `security-engineer`, `reviewer`
 
 Product and UX:
-- `@Requirements-Engineer`, `@Web-Designer`, `@AI-Engineer`
+- `requirements-engineer`, `web-designer`, `ai-engineer`
 
 ## Dynamic Specialists
 
 When a specific domain is needed, you can request it directly:
 
 ```text
-@React-Developer implement the UI
-@Kubernetes-Engineer review the deployment approach
-@Postgres-Engineer tune this query plan
+react-developer implement the UI
+kubernetes-engineer review the deployment approach
+postgres-engineer tune this query plan
 ```
 
 ## Recommended Workflow
 
-1. Start with `@PM` to break work into `.agent/queue/` items (especially for medium+ tasks).
+1. Start with `pm` to break work into `.agent/queue/` items (especially for medium+ tasks).
 2. Implement with the appropriate role.
-3. Run `@Reviewer` (or the `reviewer` skill) before committing / opening a PR.
+3. Run `reviewer` before committing / opening a PR.
 4. For PRs, require an `ICA-REVIEW-RECEIPT` (Stage 3, temp checkout) as the review gate.
 
 See `docs/workflow-guide.md` for details.
-

--- a/ica.config.default.json
+++ b/ica.config.default.json
@@ -41,7 +41,7 @@
   },
 
   "team": {
-    "default_reviewer": "@Architect",
+    "default_reviewer": "architect",
     "specialist_creation": true,
     "role_validation": true
   },
@@ -204,7 +204,7 @@
   ],
   "auto_commit_review": {
     "enabled": false,
-    "command": "@codex review"
+    "command": "codex review"
   },
   "infrastructure_protection": {
       "enabled": true,

--- a/sample-configs/ica.config.main-scope-dev.json
+++ b/sample-configs/ica.config.main-scope-dev.json
@@ -23,7 +23,7 @@
     "output_best_practices": true,
     "auto_commit_review": {
       "enabled": true,
-      "command": "@codex review"
+      "command": "codex review"
     },
     "heredoc_allowed_commands": ["git", "gh", "glab", "hub"],
     "pm_allowed_bash_commands": ["gh pr list", "gh pr view", "gh pr status"],

--- a/scripts/discover-agent-targets.sh
+++ b/scripts/discover-agent-targets.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Discover which agent "homes" likely exist on this machine.
+#
+# Output: space-separated list of agent identifiers:
+#   claude codex cursor gemini antigravity
+#
+# Overrides:
+#   ICA_DISCOVER_TARGETS="claude,codex"  (explicit list)
+#   ICA_DISCOVER_ALL=1                  (return all supported targets)
+
+normalize_list() {
+  # Accept comma/space/newline separated values; output space-separated unique values.
+  tr ',\n' '  ' | awk 'NF {print tolower($0)}' | xargs -n1 | awk 'NF' | sort -u | xargs
+}
+
+if [[ -n "${ICA_DISCOVER_TARGETS:-}" ]]; then
+  echo "${ICA_DISCOVER_TARGETS}" | normalize_list
+  exit 0
+fi
+
+if [[ "${ICA_DISCOVER_ALL:-0}" == "1" ]]; then
+  echo "claude codex cursor gemini antigravity"
+  exit 0
+fi
+
+os="$(uname -s 2>/dev/null || true)"
+home="${HOME:-}"
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+has_dir() { [[ -n "$1" && -d "$1" ]]; }
+
+targets=()
+
+# Claude Code
+if has_dir "${home}/.claude" || has_cmd claude; then
+  targets+=("claude")
+fi
+
+# Codex (Desktop/CLI)
+if has_dir "${home}/.codex" || has_cmd codex || ([[ "$os" == "Darwin" ]] && has_dir "/Applications/Codex.app"); then
+  targets+=("codex")
+fi
+
+# Cursor (best-effort)
+if has_dir "${home}/.cursor" || has_cmd cursor || \
+   ([[ "$os" == "Darwin" ]] && has_dir "/Applications/Cursor.app") || \
+   has_dir "${home}/Library/Application Support/Cursor" || \
+   has_dir "${home}/.config/Cursor"; then
+  targets+=("cursor")
+fi
+
+# Gemini CLI (best-effort; tool-specific wiring varies)
+if has_dir "${home}/.gemini" || has_cmd gemini || has_dir "${home}/.config/gemini"; then
+  targets+=("gemini")
+fi
+
+# Antigravity (best-effort; tool-specific wiring varies)
+if has_dir "${home}/.antigravity" || has_cmd antigravity; then
+  targets+=("antigravity")
+fi
+
+printf "%s\n" "${targets[@]}" | sort -u | xargs

--- a/src/agenttask-templates/large-agenttask-template.yaml
+++ b/src/agenttask-templates/large-agenttask-template.yaml
@@ -44,7 +44,7 @@ complete_context:
     unlimited_domains: "Support ANY technology domain through dynamic specialist creation"
     role_assignment: "PM + Specialist Architect determine when specialists should be created"
     coordination_specialists: "Create coordination specialists for complex multi-component features"
-    domain_examples: "@React-Developer, @AWS-Engineer, @Kubernetes-DevOps-Engineer, @API-Architect"
+    domain_examples: "react-developer, aws-engineer, kubernetes-devops-engineer, api-architect"
 
 # MANDATORY: Requirements Section
 requirements:

--- a/src/agenttask-templates/medium-agenttask-template.yaml
+++ b/src/agenttask-templates/medium-agenttask-template.yaml
@@ -38,7 +38,7 @@ complete_context:
     specialist_creation: "ALWAYS create specialists when technology expertise is needed"
     unlimited_domains: "Support ANY technology domain through dynamic specialist creation"
     role_assignment: "PM + Specialist Architect determine when specialists should be created"
-    domain_examples: "@React-Developer, @AWS-Engineer, @Kubernetes-DevOps-Engineer, @Vue-Frontend-Developer"
+    domain_examples: "react-developer, aws-engineer, kubernetes-devops-engineer, vue-frontend-developer"
 
 # MANDATORY: Requirements Section
 requirements:

--- a/src/agenttask-templates/mega-agenttask-template.yaml
+++ b/src/agenttask-templates/mega-agenttask-template.yaml
@@ -49,7 +49,7 @@ complete_context:
     role_assignment: "PM + Specialist Architect determine when specialists should be created"
     system_specialists: "Create system-wide specialists for architectural changes"
     coordination_architects: "Create coordination architects for mega-scale implementations"
-    domain_examples: "@System-Architect, @Migration-Specialist, @Legacy-Integration-Engineer, @Performance-Architect"
+    domain_examples: "system-architect, migration-specialist, legacy-integration-engineer, performance-architect"
 
 # MANDATORY: Requirements Section
 requirements:

--- a/src/agenttask-templates/nano-agenttask-template.yaml
+++ b/src/agenttask-templates/nano-agenttask-template.yaml
@@ -1,7 +1,7 @@
 # Nano AgentTask Template - Trivial Changes (0-2 points)
 # For simple one-line fixes, typos, and minimal adjustments
 
-# === TEMPLATE METADATA (@PM COORDINATES, SYSTEM FILLS) ===
+# === TEMPLATE METADATA (PM COORDINATES, SYSTEM FILLS) ===
 git_privacy: [GIT_PRIVACY_SETTING]
 id: "[PARENT_ID]-AGENTTASK-[NEXT_NUMBER]-[TITLE]-[CURRENT_DATE]"
 title: "[ROLE] [DESCRIPTION]"
@@ -36,7 +36,7 @@ complete_context:
     unlimited_domains: "Support ANY technology domain through dynamic specialist creation"
     role_assignment: "PM + Specialist Architect determine when specialists should be created"
 
-# === WORK SPECIFICATION (@PM COORDINATES, ASSIGNED ROLE ANALYZES) ===
+# === WORK SPECIFICATION (PM COORDINATES, ASSIGNED ROLE ANALYZES) ===
 user_request: "[USER_REQUEST]"
 success_criteria: "[SUCCESS_CRITERIA]"
 target_file: "[TARGET_FILE]"

--- a/src/docs/xml-constraint-registry.md
+++ b/src/docs/xml-constraint-registry.md
@@ -247,20 +247,20 @@ This registry documents all constraint IDs used in the intelligent-code-agents v
 
 **Rules**:
 - Always create specialist architects for domain expertise
-- Never use generic @Architect - precision required
+- Never use generic architect - precision required
 - Unlimited specialist creation based on technology expertise needs
 
 **Naming Pattern**: `@[Domain]-[RoleType]`
 
 **Examples**:
-- @React-Architect
-- @Database-Architect
-- @Security-Architect
-- @AI-Architect
-- @React-Developer
-- @AWS-Engineer
-- @ML-Specialist
-- @Kubernetes-DevOps-Engineer
+- react-architect
+- database-architect
+- security-architect
+- ai-architect
+- react-developer
+- aws-engineer
+- ml-specialist
+- kubernetes-devops-engineer
 
 ## Meta Rules
 

--- a/src/docs/xml-schema-design.md
+++ b/src/docs/xml-schema-design.md
@@ -263,16 +263,16 @@ This document defines the XML schema structure for critical enforcement rules in
     <description>Dynamic specialist creation for technology domains</description>
     <rules>
       <rule>Always create specialist architects for domain expertise</rule>
-      <rule>Examples: @React-Architect, @Database-Architect, @Security-Architect, @AI-Architect</rule>
-      <rule>Never use generic @Architect - precision required</rule>
+      <rule>Examples: react-architect, database-architect, security-architect, ai-architect</rule>
+      <rule>Never use generic architect - precision required</rule>
       <rule>Unlimited specialist creation based on technology expertise needs</rule>
     </rules>
     <naming_pattern>@[Domain]-[RoleType]</naming_pattern>
     <examples>
-      <example>@React-Developer</example>
-      <example>@AWS-Engineer</example>
-      <example>@ML-Specialist</example>
-      <example>@Kubernetes-DevOps-Engineer</example>
+      <example>react-developer</example>
+      <example>aws-engineer</example>
+      <example>ml-specialist</example>
+      <example>kubernetes-devops-engineer</example>
     </examples>
   </specialist_creation>
 </role_assignment>
@@ -312,7 +312,7 @@ This document defines the XML schema structure for critical enforcement rules in
   <operation>Write to src/hooks/pretooluse.js</operation>
   <result>BLOCKED</result>
   <reason>PM cannot modify technical files in src/ directory</reason>
-  <guidance>Create AgentTask for @AI-Engineer to handle technical modifications</guidance>
+  <guidance>Create AgentTask for ai-engineer to handle technical modifications</guidance>
 </validation_check>
 ```
 

--- a/src/modes/virtual-team.md
+++ b/src/modes/virtual-team.md
@@ -10,16 +10,16 @@ Skills-first architecture with 14 core roles + dynamic specialists.
 
 ## Core Principles
 
-**P1:** Skills loaded from `~/.claude/skills/` on demand
-**P2:** @Role mentions trigger role skills (pm, architect, developer, etc.)
-**P3:** /skill-name invokes specific skills directly
+**P1:** Skills are loaded from your agent home `skills/` directory on demand (for example `$ICA_HOME/skills/`)
+**P2:** Use role skills by name (pm, architect, developer, reviewer, etc.)
+**P3:** If your client supports it, `/skill-name` invokes specific skills directly
 **P4:** Hooks enforce file placement, git safety, infrastructure protection
 **P5:** AgentTask-driven execution for all significant work
 
 ## Role Activation
 
-**@Role → Skill**: @PM activates `/pm` skill, @Developer activates `/developer` skill
-**Dynamic Specialists**: Created as needed (@React-Developer, @AWS-Engineer)
+**Role skill → Skill**: `pm` activates `/pm`, `developer` activates `/developer`
+**Dynamic Specialists**: Created as needed (for example `react-developer`, `aws-engineer`)
 **Execution**: Via Task tool with embedded AgentTask context
 
 ## Operation

--- a/src/planning/planning-behaviors.md
+++ b/src/planning/planning-behaviors.md
@@ -4,7 +4,7 @@
 
 ## Planning Mode
 
-When user says "plan", "@PM plan", or similar:
+When user says "plan", "pm plan", or similar:
 - PM and Architect engage in dialogue with user
 - Create structured assignment files
 - Break down work into phases and tasks
@@ -22,10 +22,10 @@ phases:
   - name: Analysis
     deliverables:
       - name: requirements
-        tasks:
-          - id: TASK-001
-            name: Define requirements
-            role: @Requirements-Engineer
+            tasks:
+              - id: TASK-001
+                name: Define requirements
+                role: requirements-engineer
 ```
 
 ## Phase Flow
@@ -37,7 +37,7 @@ Each phase must complete before next begins.
 ## Task Creation
 
 - Every task needs unique ID (TASK-XXX)
-- Every task needs assigned @Role
+- Every task needs an assigned role skill
 - Track dependencies between tasks
 - Update status as work progresses
 

--- a/src/roles/specialists.md
+++ b/src/roles/specialists.md
@@ -2,35 +2,35 @@
 
 ## 14 Core Role Skills
 
-Each @Role mention activates the corresponding skill from `~/.claude/skills/`:
+Each role maps to a skill that lives under your agent home directory (for example `$ICA_HOME/skills/`).
 
-| @Role | Skill | Focus |
+| Role skill | Skill | Focus |
 |-------|-------|-------|
-| @PM | `/pm` | Project coordination, task delegation |
-| @Architect | `/architect` | System architecture, technical design |
-| @Developer | `/developer` | Software implementation, feature development |
-| @System-Engineer | `/system-engineer` | Infrastructure, system operations |
-| @DevOps-Engineer | `/devops-engineer` | CI/CD, deployment automation |
-| @Database-Engineer | `/database-engineer` | Database design, query optimization |
-| @Security-Engineer | `/security-engineer` | Security reviews, vulnerability assessment |
-| @AI-Engineer | `/ai-engineer` | AI/ML systems, intelligent automation |
-| @Web-Designer | `/web-designer` | UI/UX design, user experience |
-| @QA-Engineer | `/qa-engineer` | Quality assurance, test planning |
-| @Backend-Tester | `/backend-tester` | Backend testing, API validation |
-| @Requirements-Engineer | `/requirements-engineer` | Requirements analysis, documentation |
-| @User-Role | `/user-tester` | End-to-end testing, browser automation |
-| @Reviewer | `/reviewer` | Critical review, risk assessment |
+| pm | `/pm` | Project coordination, task delegation |
+| architect | `/architect` | System architecture, technical design |
+| developer | `/developer` | Software implementation, feature development |
+| system-engineer | `/system-engineer` | Infrastructure, system operations |
+| devops-engineer | `/devops-engineer` | CI/CD, deployment automation |
+| database-engineer | `/database-engineer` | Database design, query optimization |
+| security-engineer | `/security-engineer` | Security reviews, vulnerability assessment |
+| ai-engineer | `/ai-engineer` | AI/ML systems, intelligent automation |
+| web-designer | `/web-designer` | UI/UX design, user experience |
+| qa-engineer | `/qa-engineer` | Quality assurance, test planning |
+| backend-tester | `/backend-tester` | Backend testing, API validation |
+| requirements-engineer | `/requirements-engineer` | Requirements analysis, documentation |
+| user-tester | `/user-tester` | End-to-end testing, browser automation |
+| reviewer | `/reviewer` | Critical review, risk assessment |
 
 ## Dynamic Specialist Creation
 
 **Create specialists for ANY technology domain:**
-- @React-Developer, @AWS-Engineer, @Vue-Frontend-Developer
+- React developer, AWS engineer, Vue frontend developer
 - All specialists operate with 10+ years expertise
 - Created based on project needs, not predefined lists
 
 **Process:**
 1. Analyze technology stack from work context
-2. Create @[Domain]-Developer or @[Technology]-Engineer
+2. Create a specialist role skill name (for example `react-developer` or `aws-engineer`)
 3. Specialist embodies full domain expertise
 
-**Communication:** `@Role: [action]` activates skill and assigns work
+**Communication:** `role-skill: [action]` activates the skill and assigns work (for example `reviewer: run a regression review`)

--- a/src/skills/ai-engineer/SKILL.md
+++ b/src/skills/ai-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-engineer
-description: Activate when user needs AI/ML work - model integration, behavioral frameworks, intelligent automation. Activate when @AI-Engineer is mentioned or work involves machine learning, agentic systems, or AI-driven features.
+description: Activate when user needs AI/ML work - model integration, behavioral frameworks, intelligent automation. Activate when the ai-engineer skill is requested or work involves machine learning, agentic systems, or AI-driven features.
 ---
 
 # AI Engineer Role

--- a/src/skills/architect/SKILL.md
+++ b/src/skills/architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-description: Activate when user needs architectural decisions, system design, technology selection, or design reviews. Activate when @Architect is mentioned or work requires structural decisions. Provides design patterns and architectural guidance.
+description: Activate when user needs architectural decisions, system design, technology selection, or design reviews. Activate when the architect skill is requested or work requires structural decisions. Provides design patterns and architectural guidance.
 ---
 
 # Architect Role
@@ -17,7 +17,7 @@ System architecture specialist with 10+ years expertise in system design and arc
 
 ## PM + Architect Collaboration
 
-**MANDATORY**: Work closely with @PM for role assignment decisions:
+**MANDATORY**: Work closely with the pm skill for role assignment decisions:
 - Apply two-factor analysis (project scope + work type)
 - Create domain-specific specialist architects dynamically
 - Document role assignment rationale in work items
@@ -27,8 +27,8 @@ System architecture specialist with 10+ years expertise in system design and arc
 
 Create specialists when work requires domain expertise:
 - **Analyze Domain**: Extract technology stack from work context
-- **Create Specialists**: @[Domain]-Architect, @[Technology]-Engineer
-- **Examples**: @React-Architect, @Database-Architect, @Security-Architect
+- **Create Specialists**: `[domain]-architect`, `[technology]-engineer`
+- **Examples**: `react-architect`, `database-architect`, `security-architect`
 
 ## System Nature Analysis
 

--- a/src/skills/autonomy/SKILL.md
+++ b/src/skills/autonomy/SKILL.md
@@ -49,7 +49,7 @@ After work completes:
 
 **Triggers queue addition:**
 - Action verbs: implement, fix, create, deploy, update, refactor
-- @Role patterns: "@Developer implement X"
+- Role skill patterns: "developer implement X"
 - Continuation: testing after implementation
 
 **Direct response (no queue):**

--- a/src/skills/backend-tester/SKILL.md
+++ b/src/skills/backend-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-tester
-description: Activate when user needs API or backend testing - REST/GraphQL validation, integration tests, database verification. Activate when @Backend-Tester is mentioned or work requires backend quality assurance.
+description: Activate when user needs API or backend testing - REST/GraphQL validation, integration tests, database verification. Activate when the backend-tester skill is requested or work requires backend quality assurance.
 ---
 
 # Backend Tester Role

--- a/src/skills/database-engineer/SKILL.md
+++ b/src/skills/database-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: database-engineer
-description: Activate when user needs database work - schema design, query optimization, migrations, data modeling. Activate when @Database-Engineer is mentioned or work involves database design or performance tuning.
+description: Activate when user needs database work - schema design, query optimization, migrations, data modeling. Activate when the database-engineer skill is requested or work involves database design or performance tuning.
 ---
 
 # Database Engineer Role

--- a/src/skills/developer/SKILL.md
+++ b/src/skills/developer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-description: Activate when user asks to code, build, implement, create, fix bugs, refactor, or write software. Activate when @Developer is mentioned. Provides implementation patterns and coding standards for hands-on development work.
+description: Activate when user asks to code, build, implement, create, fix bugs, refactor, or write software. Activate when the developer skill is requested. Provides implementation patterns and coding standards for hands-on development work.
 ---
 
 # Developer Role

--- a/src/skills/devops-engineer/SKILL.md
+++ b/src/skills/devops-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-engineer
-description: Activate when user needs CI/CD or deployment work - pipeline design, deployment automation, release management. Activate when @DevOps-Engineer is mentioned or work involves build systems or infrastructure automation.
+description: Activate when user needs CI/CD or deployment work - pipeline design, deployment automation, release management. Activate when the devops-engineer skill is requested or work involves build systems or infrastructure automation.
 ---
 
 # DevOps Engineer Role

--- a/src/skills/ica-get-setting/SKILL.md
+++ b/src/skills/ica-get-setting/SKILL.md
@@ -28,7 +28,7 @@ Retrieve configuration settings from the ICA configuration hierarchy.
 ```
 /ica-get-setting git.privacy
 /ica-get-setting autonomy.level L2
-/ica-get-setting team.default_reviewer @Architect
+/ica-get-setting team.default_reviewer architect
 /ica-get-setting paths.memory
 ```
 

--- a/src/skills/pm/SKILL.md
+++ b/src/skills/pm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm
-description: Activate when user needs coordination, story breakdown, task delegation, or progress tracking. Activate when @PM is mentioned or work requires planning before implementation. PM coordinates specialists but does not implement.
+description: Activate when user needs coordination, story breakdown, task delegation, or progress tracking. Activate when the pm skill is requested or work requires planning before implementation. PM coordinates specialists but does not implement.
 ---
 
 # PM Role
@@ -35,7 +35,7 @@ Project management and coordination specialist with 10+ years expertise in agile
 ## Dynamic Specialist Creation
 
 **ALWAYS** create specialists when technology expertise is needed:
-- Create @React-Developer, @AWS-Engineer, @Security-Architect as needed
+- Create `react-developer`, `aws-engineer`, `security-architect` role skills as needed
 - No capability thresholds - create when expertise is beneficial
 - Document specialist creation rationale
 

--- a/src/skills/pr-automerge/SKILL.md
+++ b/src/skills/pr-automerge/SKILL.md
@@ -33,7 +33,7 @@ Review via subagent -> ICA-REVIEW receipt -> merge when NO FINDINGS -> otherwise
    - base branch, head SHA, head branch
    - checks status
 2. Run Stage 3 review via a dedicated reviewer subagent:
-   - Use Task tool to create `@Reviewer` and run Reviewer Stage 3 in a temp checkout.
+   - Use your Task/sub-agent mechanism to run Reviewer Stage 3 in a temp checkout.
    - Reviewer must fix findings by pushing commits to the PR branch.
    - Reviewer must re-run Stage 3 until findings are zero and checks are green.
    - Reviewer must post `ICA-REVIEW-RECEIPT` NO FINDINGS comment for the current head SHA.

--- a/src/skills/process/SKILL.md
+++ b/src/skills/process/SKILL.md
@@ -196,7 +196,7 @@ IF clean: Continue
 ```
 
 **Required behavior (closed-loop):**
-- Stage 3 MUST be executed by a dedicated reviewer subagent (preferred: `@Reviewer` via Task tool).
+- Stage 3 MUST be executed by a dedicated reviewer subagent (recommended: a reviewer-only subagent via your Task/sub-agent mechanism).
 - Reviewer Stage 3 MUST loop until the PR is clean:
   - If findings exist: fix + push commits to the PR branch, then restart Stage 3 in a fresh temp checkout.
   - When clean: post `ICA-REVIEW-RECEIPT` with `Findings: 0` and `NO FINDINGS` for the current head SHA.

--- a/src/skills/qa-engineer/SKILL.md
+++ b/src/skills/qa-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-engineer
-description: Activate when user needs test planning or QA strategy - test frameworks, quality metrics, test automation. Activate when @QA-Engineer is mentioned or work requires comprehensive quality assurance approach.
+description: Activate when user needs test planning or QA strategy - test frameworks, quality metrics, test automation. Activate when the qa-engineer skill is requested or work requires a comprehensive quality assurance approach.
 ---
 
 # QA Engineer Role

--- a/src/skills/requirements-engineer/SKILL.md
+++ b/src/skills/requirements-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requirements-engineer
-description: Activate when user needs requirements gathering - business analysis, specification development, user stories. Activate when @Requirements-Engineer is mentioned or work requires bridging business and technical understanding.
+description: Activate when user needs requirements gathering - business analysis, specification development, user stories. Activate when the requirements-engineer skill is requested or work requires bridging business and technical understanding.
 ---
 
 # Requirements Engineer Role

--- a/src/skills/reviewer/SKILL.md
+++ b/src/skills/reviewer/SKILL.md
@@ -94,7 +94,7 @@ If (and only if) Stage 3 is clean (no blocking findings) and the required checks
 
 **Rules:**
 - Stage 3 MUST run in an isolated context.
-  - Preferred: run Stage 3 as a dedicated reviewer subagent (for example `@Reviewer`) using the Task tool.
+  - Preferred: run Stage 3 as a dedicated reviewer subagent using your Task/sub-agent mechanism.
   - Fallback: use a fresh temp clone/checkout and treat it as the dedicated reviewer/subagent context.
 - The ICA-REVIEW comment MUST match the PR's current head SHA. If new commits are pushed after the comment,
   Stage 3 must be re-run and a new ICA-REVIEW comment posted.
@@ -121,7 +121,7 @@ gh pr comment "$PR" --body "$(cat <<EOF
 ICA-REVIEW
 ICA-REVIEW-RECEIPT
 Reviewer-Stage: 3 (temp checkout)
-Reviewer-Agent: @Reviewer (subagent)
+Reviewer-Agent: reviewer (subagent)
 PR: #$PR
 Base: $BASE_BRANCH
 Head-SHA: $HEAD_SHA

--- a/src/skills/security-engineer/SKILL.md
+++ b/src/skills/security-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-engineer
-description: Activate when user needs security work - vulnerability assessment, security architecture, compliance audits, penetration testing. Activate when @Security-Engineer is mentioned or work requires security review.
+description: Activate when user needs security work - vulnerability assessment, security architecture, compliance audits, penetration testing. Activate when the security-engineer skill is requested or work requires security review.
 ---
 
 # Security Engineer Role

--- a/src/skills/story-breakdown/SKILL.md
+++ b/src/skills/story-breakdown/SKILL.md
@@ -19,7 +19,7 @@ Break large stories into work items in `.agent/queue/`.
 1. **Analyze scope** - Identify distinct work units
 2. **Define items** - Create work item for each unit
 3. **Set dependencies** - Note which items block others
-4. **Assign roles** - Tag with @Role for execution
+4. **Assign roles** - Specify the role skill for execution (for example `developer`, `reviewer`)
 5. **Add to queue** - Create files in `.agent/queue/`
 
 ## Work Item Creation
@@ -31,7 +31,7 @@ For each item, create in `.agent/queue/`:
 
 **Status**: pending
 **Priority**: high | medium | low
-**Assignee**: @Developer | @Reviewer | etc.
+**Assignee**: developer | reviewer | etc.
 **Blocks**: 002, 003 (optional)
 **BlockedBy**: none | 001 (optional)
 

--- a/src/skills/system-engineer/SKILL.md
+++ b/src/skills/system-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: system-engineer
-description: Activate when user needs infrastructure or system operations work - system reliability, monitoring, capacity planning. Activate when @System-Engineer is mentioned or work involves configuration management or operational excellence.
+description: Activate when user needs infrastructure or system operations work - system reliability, monitoring, capacity planning. Activate when the system-engineer skill is requested or work involves configuration management or operational excellence.
 ---
 
 # System Engineer Role

--- a/src/skills/thinking/SKILL.md
+++ b/src/skills/thinking/SKILL.md
@@ -26,12 +26,12 @@ Structured problem-solving through explicit step-by-step analysis.
 
 ### Work Triggers (require planning)
 - Action verbs: implement, fix, create, deploy
-- @Role work: "@Developer implement X"
+- Role skill work: "developer implement X"
 - Continuation: testing after implementation
 
 ### Information Patterns (direct response)
 - Questions: what, how, why, status
-- @Role consultation: "@PM what story next?"
+- Role skill consultation: "pm what story next?"
 
 ### Context Evaluation
 - **Simple**: Single question, surface-level → direct response

--- a/src/skills/user-tester/SKILL.md
+++ b/src/skills/user-tester/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: user-tester
-description: Activate when user needs E2E or user journey testing - browser automation, Puppeteer/Playwright, cross-browser testing. Activate when @User-Tester is mentioned or work requires user flow validation or experience verification.
+description: Activate when user needs E2E or user journey testing - browser automation, Puppeteer/Playwright, cross-browser testing. Activate when the user-tester skill is requested or work requires user flow validation or experience verification.
 ---
 
 # User Tester Role

--- a/src/skills/web-designer/SKILL.md
+++ b/src/skills/web-designer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-designer
-description: Activate when user needs UI/UX design work - interface design, user research, design systems, accessibility. Activate when @Web-Designer is mentioned or work requires visual design or user experience expertise.
+description: Activate when user needs UI/UX design work - interface design, user research, design systems, accessibility. Activate when the web-designer skill is requested or work requires visual design or user experience expertise.
 ---
 
 # Web Designer Role

--- a/src/skills/work-queue/SKILL.md
+++ b/src/skills/work-queue/SKILL.md
@@ -46,7 +46,7 @@ Each work item is a simple markdown file:
 
 **Status**: pending | in_progress | completed | blocked
 **Priority**: high | medium | low
-**Assignee**: @Developer | @Reviewer | etc.
+**Assignee**: developer | reviewer | etc.
 
 ## Description
 What needs to be done.


### PR DESCRIPTION
Adds best-effort tool discovery and multi-target install/uninstall commands (Makefile + install.ps1), plus explicit project-only install helpers. Removes @Role/@Agent role-mention samples from docs/configs and standardizes on skill-first invocation examples.