### PR TITLE
docs(skills): portable memory CLI + exports fallback

### DIFF
--- a/src/skills/best-practices/SKILL.md
+++ b/src/skills/best-practices/SKILL.md
@@ -36,7 +36,6 @@ Best practices are stored in `best-practices/<category>/`:
    ```
 3. **Search memory** for related patterns:
    ```bash
-<<<<<<< HEAD
    # Portable: resolve memory CLI location (prefers ICA_HOME when set)
    MEMORY_CLI=""
    for d in "${ICA_HOME:-}" "$HOME/.codex" "$HOME/.claude"; do
@@ -56,9 +55,6 @@ Best practices are stored in `best-practices/<category>/`:
        grep -R "<relevant keywords>" memory/exports
      fi
    fi
-=======
-   node /skills/memory/cli.js search "<relevant keywords>"
->>>>>>> origin/dev
    ```
 4. **Apply** established patterns to implementation
 5. **Note** deviations with justification

--- a/src/skills/memory/SKILL.md
+++ b/src/skills/memory/SKILL.md
@@ -252,7 +252,6 @@ If the memory skill's dependencies are installed:
 
 ```bash
 # Path to CLI (adjust for your installation)
-<<<<<<< HEAD
 #
 # Portable (Linux/macOS):
 # - Prefer ICA_HOME if set (works for custom installs like ~/.ica)
@@ -276,16 +275,6 @@ node "$MEMORY_CLI" --help
 
 # Write a memory
 node "$MEMORY_CLI" write \
-=======
-MEMORY_CLI="$HOME/.claude/skills/memory/cli.js"  # Linux/macOS
-# $env:USERPROFILE\.claude\skills\memory\cli.js   # Windows
-
-# Check if CLI is available
-node $MEMORY_CLI --help
-
-# Write a memory
-node $MEMORY_CLI write \
->>>>>>> origin/dev
   --title "JWT Authentication" \
   --summary "Use 15-min access tokens with refresh tokens" \
   --tags "auth,jwt,security" \
@@ -293,7 +282,6 @@ node $MEMORY_CLI write \
   --importance "high"
 
 # Search (hybrid: keyword + semantic)
-<<<<<<< HEAD
 node "$MEMORY_CLI" search "authentication tokens"
 
 # Quick search (keyword only, faster)
@@ -307,21 +295,6 @@ node "$MEMORY_CLI" get mem-001
 
 # Statistics
 node "$MEMORY_CLI" stats
-=======
-node $MEMORY_CLI search "authentication tokens"
-
-# Quick search (keyword only, faster)
-node $MEMORY_CLI quick "jwt"
-
-# List memories
-node $MEMORY_CLI list --category architecture
-
-# Get specific memory
-node $MEMORY_CLI get mem-001
-
-# Statistics
-node $MEMORY_CLI stats
->>>>>>> origin/dev
 ```
 
 ### Method 2: Manual Markdown (Fallback)

--- a/src/skills/process/SKILL.md
+++ b/src/skills/process/SKILL.md
@@ -66,7 +66,6 @@ feature/* ← WHERE WORK HAPPENS
 ### Step 1.0: Memory Check (AUTOMATIC)
 ```
 BEFORE implementing, search memory:
-<<<<<<< HEAD
 
   # Portable: resolve memory CLI location (prefers ICA_HOME when set)
   MEMORY_CLI=""
@@ -87,9 +86,6 @@ BEFORE implementing, search memory:
       grep -R "relevant keywords" memory/exports
     fi
   fi
-=======
-  node /skills/memory/cli.js search "relevant keywords"
->>>>>>> origin/dev
 
 IF similar problem solved before:
   - Review the solution
@@ -149,7 +145,6 @@ IF clean or user says proceed:
 ### Step 1.5: Memory Save (AUTOMATIC)
 ```
 IF key decision was made (architecture, pattern, fix):
-<<<<<<< HEAD
   # Portable: resolve memory CLI location (prefers ICA_HOME when set)
   MEMORY_CLI=""
   for d in "${ICA_HOME:-}" "$HOME/.codex" "$HOME/.claude"; do
@@ -187,12 +182,6 @@ created: YYYY-MM-DDTHH:MM:SSZ
 ...
 EOF
   fi
-=======
-  node /skills/memory/cli.js write \
-    --title "..." --summary "..." \
-    --category "architecture|implementation|issues|patterns" \
-    --importance "high|medium|low"
->>>>>>> origin/dev
 
 This step is SILENT - auto-saves significant decisions.
 ```

--- a/src/skills/reviewer/SKILL.md
+++ b/src/skills/reviewer/SKILL.md
@@ -262,7 +262,6 @@ After fixing recurring issues, auto-save to memory:
 
 ```bash
 # When a pattern emerges (same fix multiple times):
-<<<<<<< HEAD
 # Portable: resolve memory CLI location (prefers ICA_HOME when set)
 MEMORY_CLI=""
 for d in "${ICA_HOME:-}" "$HOME/.codex" "$HOME/.claude"; do
@@ -299,14 +298,6 @@ created: YYYY-MM-DDTHH:MM:SSZ
 <what to check for and how to fix>
 EOF
 fi
-=======
-node /skills/memory/cli.js write \
-  --title "Recurring: <issue type>" \
-  --summary "<what to check for and how to fix>" \
-  --tags "recurring,security|quality|patterns" \
-  --category "issues" \
-  --importance "medium"
->>>>>>> origin/dev
 ```
 
 This is **SILENT** - no user notification. Builds knowledge for future reviews.

--- a/src/skills/thinking/SKILL.md
+++ b/src/skills/thinking/SKILL.md
@@ -53,7 +53,6 @@ Structured problem-solving through explicit step-by-step analysis.
 ### Before Analysis
 ```bash
 # Search for similar problems solved before
-<<<<<<< HEAD
 # Portable: resolve memory CLI location (prefers ICA_HOME when set)
 MEMORY_CLI=""
 for d in "${ICA_HOME:-}" "$HOME/.codex" "$HOME/.claude"; do
@@ -73,9 +72,6 @@ elif [ -d "memory/exports" ]; then
     grep -R "relevant problem keywords" memory/exports
   fi
 fi
-=======
-node /skills/memory/cli.js search "relevant problem keywords"
->>>>>>> origin/dev
 
 IF similar analysis found:
   - Review the approach
@@ -86,7 +82,6 @@ IF similar analysis found:
 ### After Significant Analysis
 ```bash
 # Store valuable analysis patterns
-<<<<<<< HEAD
 # Portable: resolve memory CLI location (prefers ICA_HOME when set)
 MEMORY_CLI=""
 for d in "${ICA_HOME:-}" "$HOME/.codex" "$HOME/.claude"; do
@@ -123,14 +118,6 @@ created: YYYY-MM-DDTHH:MM:SSZ
 <approach that worked, key tradeoffs>
 EOF
 fi
-=======
-node /skills/memory/cli.js write \
-  --title "Analysis: <problem type>" \
-  --summary "<approach that worked, key tradeoffs>" \
-  --tags "analysis,<domain>" \
-  --category "patterns" \
-  --importance "medium"
->>>>>>> origin/dev
 ```
 
 This is **SILENT** - builds knowledge for future analysis without user notification.


### PR DESCRIPTION
Replaces hardcoded `node /skills/memory/cli.js ...` examples with a portable resolution sequence:

- Prefer `$ICA_HOME/skills/memory/cli.js`
- Fallback to `~/.codex/skills/memory/cli.js`
- Fallback to `~/.claude/skills/memory/cli.js`
- If no CLI is found, fallback to searching `memory/exports/**` via `rg` (or `grep`)

Updated skills:
- best-practices
- process
- thinking
- reviewer
- memory (docs only)

No behavior/runtime code changes; documentation/examples only.