### PR TITLE
feat: add ICA MCP proxy with auth, mirroring, and trust gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,10 @@ bugs/
 
 # Memory runtime state (SQLite + caches) is local-only
 .agent/memory/
+
+# MCP client configs (can contain secrets)
+.mcp.json
+src/skills/mcp-client/references/mcp-config.json
+mcp-servers.json
+mcp.json
+mcp-tokens.json

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 2. [Configuration Guide](configuration-guide.md)
 3. [Workflow Guide](workflow-guide.md)
 4. [MCP Integration (Claude Code)](mcp-integration.md)
+5. [MCP Proxy (ICA-Owned)](mcp-proxy.md)
 
 Tip: For a clean reinstall on macOS/Linux, use `make clean-install` (force uninstall + reinstall).
 

--- a/docs/mcp-proxy.md
+++ b/docs/mcp-proxy.md
@@ -1,0 +1,234 @@
+# MCP Proxy (ICA-Owned)
+
+This doc describes the **ICA MCP Proxy**: a local stdio MCP server you register once in your agent runtime, which then mirrors and brokers access to upstream MCP servers defined in `.mcp.json` and/or `$ICA_HOME/mcp-servers.json`.
+
+## Why A Proxy?
+
+Many agent runtimes require MCP servers to be registered in tool-specific config files. A proxy centralizes:
+- upstream configuration
+- authentication (OAuth + tokens)
+- tool discovery and mirroring
+
+So the user only registers one MCP server: `ica-mcp-proxy`.
+
+## Upstream Config
+
+Create one or both of:
+- project: `./.mcp.json`
+- user: `$ICA_HOME/mcp-servers.json` (or `$ICA_HOME/mcp.json`)
+
+Format:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "remote-example": {
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer ${REMOTE_API_KEY}" }
+    }
+  }
+}
+```
+
+Precedence:
+- default: `.mcp.json` overrides `$ICA_HOME/mcp-servers.json`
+- set `ICA_MCP_CONFIG_PREFER_HOME=1` to flip
+
+## Register In Your Agent Runtime
+
+Register a stdio server named `ica-mcp-proxy` that runs:
+
+`<ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_server.py`
+
+Example JSON shape (tool-specific wiring differs):
+
+```json
+{
+  "ica-mcp-proxy": {
+    "command": "python",
+    "args": ["<ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+  }
+}
+```
+
+## Multi-Agent Registration Snippets
+
+Use one of the snippets below based on your runtime. In all cases, the target command is:
+
+`python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_server.py`
+
+Replace `<ICA_HOME>` with your real agent home (for example, `~/.codex`, `~/.ica`, or a project-local install path).
+
+### Codex (`~/.codex/config.toml`)
+
+```toml
+[mcp_servers.ica-mcp-proxy]
+type = "stdio"
+command = "python3"
+args = ["/Users/<you>/.codex/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+```
+
+### Cursor (`.cursor/mcp.json` or `~/.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "ica-mcp-proxy": {
+      "command": "python3",
+      "args": ["/Users/<you>/.codex/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+    }
+  }
+}
+```
+
+### Gemini CLI (`.gemini/settings.json` or `~/.gemini/settings.json`)
+
+```json
+{
+  "mcpServers": {
+    "ica-mcp-proxy": {
+      "command": "python3",
+      "args": ["/Users/<you>/.codex/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+    }
+  }
+}
+```
+
+### OpenCode (`opencode.json` or `~/.config/opencode/opencode.json`)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ica-mcp-proxy": {
+      "type": "local",
+      "command": ["python3", "/Users/<you>/.codex/skills/mcp-proxy/scripts/mcp_proxy_server.py"],
+      "enabled": true
+    }
+  }
+}
+```
+
+### Antigravity (`mcp_config.json`)
+
+Open Antigravity MCP Store, then `Manage MCP Servers` -> `View raw config`, and add:
+
+```json
+{
+  "mcpServers": {
+    "ica-mcp-proxy": {
+      "command": "python3",
+      "args": ["/Users/<you>/.codex/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+    }
+  }
+}
+```
+
+### Quick Verification
+
+- Codex: run `codex mcp list`
+- Cursor: open chat tools list after restart/reload
+- Gemini CLI: run `/mcp` in session
+- OpenCode: run `opencode mcp list`
+- Antigravity: check server status in MCP Store/Manage view
+
+## Project Trust Gate (Optional)
+
+To keep local developer UX simple, trust-gating is **off by default**.
+
+When you want stricter safety (for example when opening unfamiliar repos), enable:
+
+`export ICA_MCP_STRICT_TRUST=1`
+
+Behavior in strict mode:
+- Project `.mcp.json` servers that use `stdio` (`command`/`args`) are blocked until trusted.
+- Home/user config servers are unaffected.
+- `proxy.list_servers` and `proxy.mirror_status` include `blocked_servers` reasons.
+
+### Greenlight A Project (One command)
+
+```bash
+python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_cli.py trust
+```
+
+Useful management commands:
+
+```bash
+python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_cli.py trust-status
+python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_cli.py untrust
+python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_cli.py trust /path/to/project
+```
+
+Temporary bypass (current shell/session only):
+
+`export ICA_MCP_ALLOW_PROJECT_STDIO=1`
+
+Trust is hash-bound to `.mcp.json`. If that file changes, strict mode asks you to trust again.
+
+## How Tools Appear
+
+The proxy exposes:
+
+1. Broker tools under `proxy.*` (always available)
+2. Mirrored tools named `<server>.<tool>`
+
+Example:
+- `proxy.list_servers`
+- `proxy.call`
+- `sequential-thinking.sequentialthinking`
+
+## Authentication
+
+Tokens are stored locally in:
+- `$ICA_HOME/mcp-tokens.json`
+
+Auth entry points:
+- `proxy.auth_start(server, flow?)`
+- `proxy.auth_status(server)`
+- `proxy.auth_refresh(server)`
+- `proxy.auth_logout(server)`
+
+Supported flows:
+- PKCE (browser redirect to localhost)
+- Device code (copy/paste in browser; good for headless)
+- Client credentials (machine-to-machine)
+
+Security constraints:
+- OAuth endpoints should use `https://`.
+- `http://` OAuth endpoints are only allowed for localhost/loopback development.
+- PKCE redirect URIs must use a localhost/loopback host.
+
+How auth is triggered:
+- Explicitly call `proxy.auth_start(server, flow?)` to begin login.
+- For PKCE, the proxy opens a browser best-effort and starts a localhost callback listener.
+- For device code, the proxy returns `verification_uri` and `user_code` for manual confirmation.
+- After successful auth/refresh/logout, pooled upstream sessions are recycled so new credentials take effect.
+
+## Upstream Session Pooling (stdio)
+
+For `stdio` upstream servers, the proxy uses a dedicated worker task per upstream and reuses a live session between tool calls. This avoids known AnyIO cancel-scope teardown edge cases that can happen when session lifecycle crosses task boundaries.
+
+Controls:
+- `ICA_MCP_PROXY_POOL_STDIO` (default: `true`)
+- `ICA_MCP_PROXY_DISABLE_POOLING` (default: `false`)
+- `ICA_MCP_PROXY_UPSTREAM_IDLE_TTL_S` (default: `90`)
+- `ICA_MCP_PROXY_UPSTREAM_REQUEST_TIMEOUT_S` (default: `120`)
+
+Notes:
+- Pooling is intentionally scoped to `stdio` upstreams in MVP.
+- HTTP-based upstreams (`sse`, `streamable_http`) currently use per-operation sessions.
+
+## Mirroring Guardrails
+
+Mirroring can overwhelm some clients if upstream schemas are huge. The proxy enforces limits (env overrides supported):
+- `ICA_MCP_PROXY_MAX_SERVERS` (default 25)
+- `ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER` (default 200)
+- `ICA_MCP_PROXY_MAX_TOTAL_TOOLS` (default 2000)
+- `ICA_MCP_PROXY_MAX_SCHEMA_BYTES` (default 65536)
+- `ICA_MCP_PROXY_TOOL_CACHE_TTL_S` (default 300)
+
+Use `proxy.mirror_status()` to see truncation reasons.

--- a/src/skills/mcp-client/SKILL.md
+++ b/src/skills/mcp-client/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: mcp-client
+description: Universal MCP client for connecting to MCP servers with progressive disclosure. Use when you need to list MCP servers/tools or call an MCP tool against a server that is not already wired into the current agent runtime.
+---
+
+# MCP Client (Universal)
+
+This skill provides a small, portable CLI for connecting to MCP (Model Context Protocol) servers **on-demand**:
+- list configured servers
+- list tools for a single server (progressive disclosure)
+- call a tool with JSON arguments
+
+It is designed to avoid pasting large tool schemas into the agent context up front.
+
+## Where It Lives
+
+- When installed into an agent home (recommended): `$ICA_HOME/skills/mcp-client/` (or `~/.codex/skills/mcp-client/`, `~/.claude/skills/mcp-client/`)
+- From this repo (development/reference): `src/skills/mcp-client/`
+
+## Recommendation: Use `mcp-proxy` For “Register Once”
+
+If you want to register only a single MCP server in your agent runtime and manage upstream servers + auth centrally,
+use the `mcp-proxy` skill. It mirrors upstream tools as `<server>.<tool>` and provides stable broker tools under `proxy.*`.
+
+Script:
+
+```bash
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" --help
+```
+
+## Dependencies
+
+You need Python 3.9+ and:
+
+```bash
+pip install mcp
+```
+
+## Configuration
+
+The client resolves config in this order:
+
+1. `MCP_CONFIG_PATH` env var (path to JSON)
+2. `MCP_CONFIG` env var (inline JSON)
+3. Merge project + ICA home (default):
+   - project: `.mcp.json`
+   - user: `$ICA_HOME/mcp-servers.json` (or `$ICA_HOME/mcp.json`)
+   - default precedence: project overrides user (flip with `ICA_MCP_CONFIG_PREFER_HOME=1`)
+4. `~/.claude.json` (Claude Code compatibility fallback; reads `mcpServers` if no other config exists)
+
+To get started, copy:
+- `references/example-mcp-config.json` -> `.mcp.json` (project-local), OR
+- `references/example-mcp-config.json` -> `$ICA_HOME/mcp-servers.json` (agent-home local)
+
+Security note:
+- Do not commit real API keys. Keep `.mcp.json` and `references/mcp-config.json` local-only.
+- If you need an API key and the user hasn't provided it yet, ask for it.
+
+## Authentication (Typical Patterns)
+
+Most MCP servers require authentication. This client does not run OAuth flows for you; it only sends what you configure.
+
+Common patterns:
+
+- Remote HTTP MCP servers: set `headers.Authorization` to `Bearer <token>` (or use another header like `X-API-Key`).
+- Convenience: `api_key` is treated as sugar for `headers.Authorization = "Bearer <api_key>"`.
+- Local stdio MCP servers: set required secrets in `env` (for example `GITHUB_TOKEN`, `POSTGRES_CONNECTION_STRING`).
+- Environment placeholders: strings containing `${VAR}` are expanded from your process environment at runtime (best-effort).
+
+### OAuth (Interactive)
+
+If a server uses OAuth (not static API keys), configure an `oauth` block for that server, then run:
+
+```bash
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" auth <server_name>
+```
+
+Supported OAuth styles:
+- Authorization Code + PKCE (browser-based redirect to localhost)
+- Device Code (copy/paste a code into a browser)
+
+Tokens are stored locally in `$ICA_HOME/mcp-tokens.json` and will be used automatically for calls if the server does not already specify `headers.Authorization`.
+
+OAuth config (PKCE, explicit endpoints):
+
+```json
+{
+  "mcpServers": {
+    "remote-oauth": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "type": "pkce",
+        "authorization_url": "https://idp.example.com/oauth/authorize",
+        "token_url": "https://idp.example.com/oauth/token",
+        "client_id": "YOUR_CLIENT_ID",
+        "scopes": ["openid", "profile", "offline_access"],
+        "redirect_uri": "http://127.0.0.1:8765/callback"
+      }
+    }
+  }
+}
+```
+
+OAuth config (OIDC discovery + PKCE):
+
+```json
+{
+  "mcpServers": {
+    "remote-oidc": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "type": "oidc_pkce",
+        "issuer": "https://idp.example.com/",
+        "client_id": "YOUR_CLIENT_ID",
+        "scopes": ["openid", "profile", "offline_access"]
+      }
+    }
+  }
+}
+```
+
+OAuth config (device code):
+
+```json
+{
+  "mcpServers": {
+    "remote-device": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "type": "device_code",
+        "device_authorization_url": "https://idp.example.com/oauth/device/code",
+        "token_url": "https://idp.example.com/oauth/token",
+        "client_id": "YOUR_CLIENT_ID",
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+## Commands
+
+```bash
+# List configured servers
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" servers
+
+# List tools (with full parameter schemas) from one server
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" tools <server_name>
+
+# Call a tool
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" call <server_name> <tool_name> '{"arg":"value"}'
+```
+
+### Example: Remote MCP (Bearer Auth)
+
+```bash
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" servers
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" tools <remote-server>
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" call <remote-server> <tool_name> '{"param":"value"}'
+```
+
+### Example: Sequential Thinking (Local stdio MCP server)
+
+```bash
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" tools sequential-thinking
+python "$ICA_HOME/skills/mcp-client/scripts/mcp_client.py" call sequential-thinking sequentialthinking '{"thought":"Breaking down the problem...","thoughtNumber":1,"totalThoughts":5,"nextThoughtNeeded":true}'
+```
+
+## Config Format
+
+The config file can be either:
+- `{"mcpServers": { ... }}` (recommended), or
+- `{ ... }` where the top-level keys are server names.
+
+```json
+{
+  "mcpServers": {
+    "remote-example": {
+      "url": "https://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${REMOTE_API_KEY}"
+      }
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}
+```
+
+Transport detection:
+- `command` (+ optional `args`) -> `stdio`
+- `url` ending in `/sse` -> `sse`
+- `url` ending in `/mcp` -> `streamable_http`
+- `api_key` -> sugar for `headers.Authorization = "Bearer <api_key>"`
+
+## References
+
+- `references/mcp-servers.md` - Common server configurations
+- `references/example-mcp-config.json` - Template config file
+- `references/python-mcp-sdk.md` - Python SDK notes and examples

--- a/src/skills/mcp-client/references/example-mcp-config.json
+++ b/src/skills/mcp-client/references/example-mcp-config.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "remote-example": {
+      "url": "https://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${REMOTE_API_KEY}"
+      },
+      "_comment": "Put REMOTE_API_KEY in your environment. Optional sugar: api_key becomes headers.Authorization."
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/src/skills/mcp-client/references/mcp-servers.md
+++ b/src/skills/mcp-client/references/mcp-servers.md
@@ -1,0 +1,114 @@
+# Common MCP Server Configurations
+
+Reference configurations for popular MCP servers.
+
+Copy relevant sections to either:
+- `.mcp.json` in a project (keep it local-only), or
+- `references/mcp-config.json` next to this skill under your agent home.
+
+## Remote Servers (HTTP/SSE)
+
+### Generic Remote MCP (Bearer Auth)
+
+```json
+{
+  "remote-example": {
+    "url": "https://example.com/mcp",
+    "headers": {
+      "Authorization": "Bearer ${REMOTE_API_KEY}"
+    }
+  }
+}
+```
+
+Optional sugar (equivalent to the `headers.Authorization` above):
+
+```json
+{
+  "remote-example": {
+    "url": "https://example.com/mcp",
+    "api_key": "${REMOTE_API_KEY}"
+  }
+}
+```
+
+Legacy SSE format (if needed; endpoint must support SSE):
+
+```json
+{
+  "remote-example": {
+    "url": "https://example.com/sse",
+    "headers": {
+      "Authorization": "Bearer ${REMOTE_API_KEY}"
+    }
+  }
+}
+```
+
+Security:
+- Treat your API key like a password.
+- Do not commit it to git.
+- Prefer environment variables and `${VARS}` placeholders so secrets don't live in files.
+
+## Local Servers (stdio)
+
+### Sequential Thinking
+
+```json
+{
+  "sequential-thinking": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+  }
+}
+```
+
+Docker alternative:
+
+```json
+{
+  "sequential-thinking": {
+    "command": "docker",
+    "args": ["run", "--rm", "-i", "mcp/sequentialthinking"]
+  }
+}
+```
+
+### GitHub MCP
+
+```json
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxxxxxxxxxxx"
+    }
+  }
+}
+```
+
+### Filesystem MCP
+
+```json
+{
+  "filesystem": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/allowed/path"]
+  }
+}
+```
+
+### PostgreSQL MCP
+
+```json
+{
+  "postgres": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-postgres"],
+    "env": {
+      "POSTGRES_CONNECTION_STRING": "postgresql://user:pass@host:5432/db"
+    }
+  }
+}
+```

--- a/src/skills/mcp-client/references/python-mcp-sdk.md
+++ b/src/skills/mcp-client/references/python-mcp-sdk.md
@@ -1,0 +1,72 @@
+# Python MCP SDK Notes
+
+The Python SDK (`mcp`) can be used to connect to MCP servers over several transports.
+
+Install:
+
+```bash
+pip install mcp
+```
+
+## Client Examples
+
+### stdio transport (local subprocess servers)
+
+```python
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+server_params = StdioServerParameters(
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-github"],
+    env={"GITHUB_PERSONAL_ACCESS_TOKEN": "xxx"},
+)
+
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        tools = await session.list_tools()
+        # ...
+```
+
+### SSE transport (remote)
+
+```python
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+async with sse_client(url, headers={"Authorization": "Bearer token"}, timeout=30) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        # ...
+```
+
+### Streamable HTTP transport (remote, modern)
+
+```python
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+async with streamablehttp_client(url, headers={"Authorization": "Bearer token"}, timeout=30) as (read, write, _):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        # ...
+```
+
+### Listing tools
+
+```python
+result = await session.list_tools()
+for tool in result.tools:
+    print(tool.name, tool.description, tool.inputSchema)
+```
+
+### Calling tools
+
+```python
+result = await session.call_tool("tool_name", {"arg1": "value1"})
+for item in result.content:
+    if hasattr(item, "text"):
+        print(item.text)
+```
+

--- a/src/skills/mcp-client/scripts/mcp_client.py
+++ b/src/skills/mcp-client/scripts/mcp_client.py
@@ -1,0 +1,1001 @@
+#!/usr/bin/env python3
+"""
+Universal MCP Client - Connect to MCP servers from simple JSON config files.
+
+Why this exists:
+- Many MCP servers have large tool schemas. This CLI enables progressive disclosure:
+  list tools only when needed, for a specific server, instead of dumping schemas
+  into the agent context.
+
+Supports MCP transports:
+- stdio (local subprocess servers)
+- sse (remote, legacy-ish)
+- streamable_http (remote, modern; /mcp)
+
+Config resolution (priority order):
+1. MCP_CONFIG_PATH env var (path to config file)
+2. MCP_CONFIG env var (inline JSON)
+3. .mcp.json in current directory
+4. $ICA_HOME/mcp-servers.json (ICA canonical, agent-agnostic)
+5. references/mcp-config.json next to this script (skill-local, optional)
+6. ~/.claude.json (Claude Code compatibility; reads mcpServers)
+
+Usage:
+    python mcp_client.py servers
+    python mcp_client.py tools <server>
+    python mcp_client.py call <server> <tool> '{"arg": "value"}'
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+import threading
+import secrets
+import hashlib
+import base64
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler
+from socketserver import TCPServer
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, Optional
+
+# Share logic with ICA MCP tools when available.
+def _import_core():
+    here = Path(__file__).resolve()
+    skills_dir = here.parents[2]
+    common = skills_dir / "mcp-common" / "scripts"
+    if common.exists():
+        sys.path.insert(0, str(common))
+    try:
+        import ica_mcp_core  # type: ignore
+        return ica_mcp_core
+    except Exception:
+        return None
+
+
+_CORE = _import_core()
+
+
+# =============================================================================
+# Helpers: Output / Errors
+# =============================================================================
+
+def _print_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _print_error(message: str, error_type: str = "error") -> None:
+    _print_json({"error": message, "type": error_type})
+
+
+class DependencyError(RuntimeError):
+    pass
+
+
+def _missing_dep(dep: str, extra: str = "") -> None:
+    hint = f"Missing dependency '{dep}'. Install it with: pip install {dep}"
+    if extra:
+        hint = f"{hint}. {extra}"
+    raise DependencyError(hint)
+
+
+# =============================================================================
+# Config Loading
+# =============================================================================
+
+def _get_ica_home() -> Optional[Path]:
+    """
+    Resolve ICA_HOME in a way that works across agent runtimes.
+
+    Priority:
+    - ICA_HOME env var
+    - infer from install layout: <ICA_HOME>/skills/mcp-client/scripts/mcp_client.py
+    """
+    if os.environ.get("ICA_HOME"):
+        return Path(os.environ["ICA_HOME"]).expanduser()
+
+    script_dir = Path(__file__).resolve().parent
+    # If installed, script path looks like: <ICA_HOME>/skills/mcp-client/scripts/mcp_client.py
+    try:
+        if script_dir.parent.parent.name == "skills":
+            return script_dir.parent.parent.parent
+    except Exception:
+        return None
+
+    return None
+
+
+def _find_config_file() -> Optional[Path]:
+    script_dir = Path(__file__).resolve().parent
+    ica_home = _get_ica_home()
+
+    # 1) Explicit env var path
+    if env_path := os.environ.get("MCP_CONFIG_PATH"):
+        path = Path(env_path).expanduser()
+        if path.exists():
+            return path
+
+    # 2) Project-local config
+    local_config = Path(".mcp.json")
+    if local_config.exists():
+        return local_config
+
+    # 3) ICA canonical location (agent-agnostic)
+    if ica_home:
+        for name in ("mcp-servers.json", "mcp.json"):
+            p = (ica_home / name)
+            if p.exists():
+                return p
+
+    # 4) Skill-local config (optional; keep secrets out of git)
+    skill_config = script_dir.parent / "references" / "mcp-config.json"
+    if skill_config.exists():
+        return skill_config
+
+    # 5) Claude Code compatibility
+    claude_config = Path.home() / ".claude.json"
+    if claude_config.exists():
+        return claude_config
+
+    return None
+
+
+def _normalize_servers(config: dict) -> dict:
+    # Accept {"mcpServers": {...}} or direct {...}
+    servers = config.get("mcpServers", config)
+    if not isinstance(servers, dict):
+        raise ValueError("Config must be an object or contain an 'mcpServers' object.")
+
+    # Filter obvious non-server keys defensively when a full settings JSON is passed.
+    filtered: dict[str, Any] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if "command" in cfg or "url" in cfg:
+            filtered[name] = cfg
+    return filtered
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def _expand_env_placeholders(value: Any) -> Any:
+    """
+    Best-effort `${VAR}` expansion for config values.
+
+    - Only expands when VAR is present in the process environment.
+    - Leaves unknown placeholders unchanged (so configs remain portable).
+    """
+    if isinstance(value, str):
+        def repl(match: re.Match) -> str:
+            name = match.group(1)
+            return os.environ.get(name, match.group(0))
+
+        return _ENV_VAR_PATTERN.sub(repl, value)
+
+    if isinstance(value, list):
+        return [_expand_env_placeholders(v) for v in value]
+
+    if isinstance(value, dict):
+        return {k: _expand_env_placeholders(v) for k, v in value.items()}
+
+    return value
+
+
+def _load_servers() -> dict:
+    # Prefer shared core if present: supports merged project + ICA_HOME config.
+    if _CORE is not None:
+        loaded = _CORE.load_servers_merged(script_file=__file__)  # type: ignore[attr-defined]
+        return loaded.servers
+
+    # Fallback to legacy behavior (single config file).
+    if env_config := os.environ.get("MCP_CONFIG"):
+        try:
+            cfg = json.loads(env_config)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid MCP_CONFIG JSON: {e}") from e
+        return _normalize_servers(cfg)
+
+    config_path = _find_config_file()
+    if not config_path:
+        raise FileNotFoundError(
+            "No MCP config found. Set MCP_CONFIG_PATH or MCP_CONFIG, "
+            "or create .mcp.json in the current directory."
+        )
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+
+    servers = _normalize_servers(cfg)
+    return _expand_env_placeholders(servers)
+
+
+def _get_server_config(servers: dict, server_name: str) -> dict:
+    if server_name not in servers:
+        available = ", ".join(sorted(servers.keys())) or "(none)"
+        raise ValueError(f"Server '{server_name}' not found. Available: {available}")
+    return servers[server_name]
+
+
+# =============================================================================
+# Token Storage (OAuth)
+# =============================================================================
+
+def _tokens_path() -> Optional[Path]:
+    ica_home = _get_ica_home()
+    if not ica_home:
+        return None
+    return ica_home / "mcp-tokens.json"
+
+
+def _load_tokens() -> dict:
+    path = _tokens_path()
+    if not path or not path.exists():
+        return {"version": 1, "servers": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "servers": {}}
+        if "servers" not in data or not isinstance(data.get("servers"), dict):
+            return {"version": 1, "servers": {}}
+        return data
+    except Exception:
+        return {"version": 1, "servers": {}}
+
+
+def _save_tokens(data: dict) -> None:
+    path = _tokens_path()
+    if not path:
+        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        # Best-effort (Windows may ignore)
+        pass
+
+
+def _get_token_entry(server_name: str) -> Optional[dict]:
+    data = _load_tokens()
+    return data.get("servers", {}).get(server_name)
+
+
+def _set_token_entry(server_name: str, entry: dict) -> None:
+    data = _load_tokens()
+    data.setdefault("servers", {})[server_name] = entry
+    _save_tokens(data)
+
+
+def _delete_token_entry(server_name: str) -> bool:
+    data = _load_tokens()
+    servers = data.setdefault("servers", {})
+    if server_name in servers:
+        del servers[server_name]
+        _save_tokens(data)
+        return True
+    return False
+
+
+def _token_is_expired(entry: dict, skew_seconds: int = 30) -> bool:
+    expires_at = entry.get("expires_at")
+    if not expires_at:
+        return False
+    try:
+        return time.time() >= float(expires_at) - skew_seconds
+    except Exception:
+        return False
+
+
+# =============================================================================
+# OAuth Helpers
+# =============================================================================
+
+def _http_json_get(url: str, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _http_form_post(url: str, data: dict, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    encoded = urllib.parse.urlencode({k: v for k, v in data.items() if v is not None}).encode("utf-8")
+    hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
+    req = urllib.request.Request(url, data=encoded, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    # RFC7636: 43-128 chars. Use urlsafe token and trim.
+    verifier = secrets.token_urlsafe(64)[:96]
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _resolve_oauth_config(server_cfg: dict) -> Optional[dict]:
+    oauth = server_cfg.get("oauth")
+    if not oauth or not isinstance(oauth, dict):
+        return None
+    return oauth
+
+
+def _resolve_oauth_endpoints(oauth: dict) -> dict:
+    """
+    Return endpoints needed for the configured oauth flow.
+    Supports:
+    - oidc_pkce: issuer discovery -> authorization_endpoint + token_endpoint
+    - oidc_device_code: issuer discovery -> device_authorization_endpoint + token_endpoint
+    - pkce: uses authorization_url + token_url
+    - device_code: uses device_authorization_url + token_url
+    """
+    typ = str(oauth.get("type") or "pkce").lower()
+
+    if typ.startswith("oidc"):
+        issuer = oauth.get("issuer")
+        if not issuer:
+            raise ValueError("oauth.issuer is required for OIDC flows.")
+        well_known = str(issuer).rstrip("/") + "/.well-known/openid-configuration"
+        cfg = _http_json_get(well_known)
+        endpoints = {
+            "authorization_url": cfg.get("authorization_endpoint"),
+            "token_url": cfg.get("token_endpoint"),
+            "device_authorization_url": cfg.get("device_authorization_endpoint"),
+        }
+        return endpoints
+
+    # Non-OIDC: explicit endpoints
+    return {
+        "authorization_url": oauth.get("authorization_url"),
+        "token_url": oauth.get("token_url"),
+        "device_authorization_url": oauth.get("device_authorization_url"),
+    }
+
+
+class _OAuthRedirectHandler(BaseHTTPRequestHandler):
+    # Shared state injected at construction time via closure.
+    _event: threading.Event
+    _state: str
+    _result: dict
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        qs = urllib.parse.parse_qs(parsed.query)
+        code = (qs.get("code") or [None])[0]
+        state = (qs.get("state") or [None])[0]
+        err = (qs.get("error") or [None])[0]
+        desc = (qs.get("error_description") or [None])[0]
+
+        ok = code and state == self._state and not err
+        if ok:
+            self._result.update({"code": code, "state": state})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication complete. You can close this tab.\n")
+        else:
+            self._result.update({"error": err or "invalid_redirect", "error_description": desc, "state": state})
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication failed. Return to the terminal.\n")
+
+        self._event.set()
+
+    def log_message(self, format, *args):  # noqa: A002
+        # Silence default request logging.
+        return
+
+
+async def _oauth_auth_pkce(server_name: str, server_cfg: dict) -> dict:
+    oauth = _resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = _resolve_oauth_endpoints(oauth)
+    auth_url = endpoints.get("authorization_url")
+    token_url = endpoints.get("token_url")
+    if not auth_url or not token_url:
+        raise ValueError("OAuth PKCE requires authorization_url and token_url (or OIDC issuer).")
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    redirect_uri = oauth.get("redirect_uri") or "http://127.0.0.1:8765/callback"
+    parsed = urllib.parse.urlparse(str(redirect_uri))
+    if parsed.scheme not in ("http",):
+        raise ValueError("oauth.redirect_uri must be an http:// localhost URL.")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8765
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    extra_auth_params = oauth.get("extra_auth_params") or {}
+    if not isinstance(extra_auth_params, dict):
+        raise ValueError("oauth.extra_auth_params must be an object.")
+
+    params = {
+        "response_type": "code",
+        "client_id": str(client_id),
+        "redirect_uri": str(redirect_uri),
+        "scope": " ".join([str(s) for s in scopes]),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        **{str(k): str(v) for k, v in extra_auth_params.items()},
+    }
+    url = str(auth_url) + ("&" if "?" in str(auth_url) else "?") + urllib.parse.urlencode(params)
+
+    # Start local redirect listener.
+    event = threading.Event()
+    result: dict[str, Any] = {}
+
+    def handler_factory(*_args, **_kwargs):
+        h = _OAuthRedirectHandler(*_args, **_kwargs)
+        h._event = event
+        h._state = state
+        h._result = result
+        return h
+
+    httpd = TCPServer((host, port), handler_factory)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        # Try to open a browser; if it fails, print URL in response JSON.
+        try:
+            import webbrowser
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+        # Wait (blocking) for the redirect.
+        if not event.wait(timeout=int(oauth.get("timeout", 300))):
+            raise TimeoutError("Timed out waiting for OAuth redirect.")
+
+        if "code" not in result:
+            raise ValueError(f"OAuth redirect error: {result.get('error')} {result.get('error_description') or ''}".strip())
+
+        code = result["code"]
+
+        extra_token_params = oauth.get("extra_token_params") or {}
+        if not isinstance(extra_token_params, dict):
+            raise ValueError("oauth.extra_token_params must be an object.")
+
+        token_req = {
+            "grant_type": "authorization_code",
+            "client_id": str(client_id),
+            "code": code,
+            "redirect_uri": str(redirect_uri),
+            "code_verifier": verifier,
+            **{str(k): str(v) for k, v in extra_token_params.items()},
+        }
+        # Some providers require client_secret even with PKCE (confidential clients).
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+        access = token.get("access_token")
+        if not access:
+            raise ValueError("Token response missing access_token.")
+
+        expires_in = token.get("expires_in")
+        expires_at = None
+        try:
+            if expires_in is not None:
+                expires_at = int(time.time()) + int(expires_in)
+        except Exception:
+            expires_at = None
+
+        entry = {
+            "access_token": access,
+            "refresh_token": token.get("refresh_token"),
+            "token_type": token.get("token_type") or "Bearer",
+            "scope": token.get("scope"),
+            "expires_at": expires_at,
+            "obtained_at": int(time.time()),
+        }
+        _set_token_entry(server_name, entry)
+        return {"status": "ok", "server": server_name, "auth_url": url, "saved_to": str(_tokens_path() or "")}
+    finally:
+        try:
+            httpd.shutdown()
+            httpd.server_close()
+        except Exception:
+            pass
+
+
+async def _oauth_auth_device_code(server_name: str, server_cfg: dict) -> dict:
+    oauth = _resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = _resolve_oauth_endpoints(oauth)
+    device_url = endpoints.get("device_authorization_url")
+    token_url = endpoints.get("token_url")
+    if not device_url or not token_url:
+        raise ValueError("OAuth device code requires device_authorization_url and token_url (or OIDC issuer).")
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    req = {
+        "client_id": str(client_id),
+        "scope": " ".join([str(s) for s in scopes]),
+    }
+    device = _http_form_post(str(device_url), req, timeout=int(oauth.get("token_timeout", 30)))
+    device_code = device.get("device_code")
+    user_code = device.get("user_code")
+    verify_uri = device.get("verification_uri") or device.get("verification_uri_complete")
+    interval = int(device.get("interval") or 5)
+    expires_in = int(device.get("expires_in") or 600)
+
+    if not device_code or not user_code or not verify_uri:
+        raise ValueError("Device code response missing required fields.")
+
+    # Tell user what to do (this is the key UX for device-code).
+    started = int(time.time())
+    deadline = started + expires_in
+    instructions = {
+        "verification_uri": device.get("verification_uri"),
+        "verification_uri_complete": device.get("verification_uri_complete"),
+        "user_code": user_code,
+        "expires_in": expires_in,
+        "interval": interval,
+    }
+
+    # Poll token endpoint.
+    while int(time.time()) < deadline:
+        token_req = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": str(client_id),
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+        try:
+            token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+        except Exception as e:
+            # Many providers return 400 with JSON error; urllib raises. Best-effort parse:
+            try:
+                if hasattr(e, "read"):
+                    token = json.loads(e.read().decode("utf-8", errors="replace"))  # type: ignore[attr-defined]
+                else:
+                    raise
+            except Exception:
+                raise
+
+        if token.get("access_token"):
+            access = token["access_token"]
+            expires_at = None
+            try:
+                if token.get("expires_in") is not None:
+                    expires_at = int(time.time()) + int(token["expires_in"])
+            except Exception:
+                expires_at = None
+            entry = {
+                "access_token": access,
+                "refresh_token": token.get("refresh_token"),
+                "token_type": token.get("token_type") or "Bearer",
+                "scope": token.get("scope"),
+                "expires_at": expires_at,
+                "obtained_at": int(time.time()),
+            }
+            _set_token_entry(server_name, entry)
+            return {"status": "ok", "server": server_name, "saved_to": str(_tokens_path() or ""), "device": instructions}
+
+        # Typical OAuth device errors: authorization_pending, slow_down
+        err = token.get("error")
+        if err == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if err == "slow_down":
+            interval += 2
+            time.sleep(interval)
+            continue
+
+        raise ValueError(f"Device code auth failed: {err or 'unknown_error'}")
+
+    raise TimeoutError("Device code flow timed out.")
+
+
+def _oauth_maybe_refresh(server_name: str, server_cfg: dict) -> Optional[str]:
+    """
+    If we have a stored token for this server, refresh it if expired and possible.
+    Returns an access token if available.
+    """
+    entry = _get_token_entry(server_name)
+    if not entry or not isinstance(entry, dict):
+        return None
+
+    if not _token_is_expired(entry):
+        return entry.get("access_token")
+
+    refresh = entry.get("refresh_token")
+    oauth = _resolve_oauth_config(server_cfg)
+    if not refresh or not oauth:
+        return entry.get("access_token")
+
+    endpoints = _resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    client_id = oauth.get("client_id")
+    if not token_url or not client_id:
+        return entry.get("access_token")
+
+    token_req = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": str(client_id),
+    }
+    if oauth.get("client_secret"):
+        token_req["client_secret"] = str(oauth["client_secret"])
+
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return entry.get("access_token")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry["access_token"] = access
+    if token.get("refresh_token"):
+        entry["refresh_token"] = token.get("refresh_token")
+    entry["token_type"] = token.get("token_type") or entry.get("token_type") or "Bearer"
+    entry["scope"] = token.get("scope") or entry.get("scope")
+    entry["expires_at"] = expires_at
+    entry["obtained_at"] = int(time.time())
+    _set_token_entry(server_name, entry)
+    return access
+
+
+# =============================================================================
+# Transport Detection & Connection
+# =============================================================================
+
+def _detect_transport(config: dict) -> str:
+    # Explicit type takes precedence
+    if explicit_type := config.get("type"):
+        type_map = {
+            "stdio": "stdio",
+            "sse": "sse",
+            "http": "streamable_http",
+            "streamable_http": "streamable_http",
+            "streamable-http": "streamable_http",
+        }
+        return type_map.get(str(explicit_type).lower(), str(explicit_type).lower())
+
+    # Infer from config keys
+    if "command" in config:
+        return "stdio"
+
+    if "url" in config:
+        url = str(config["url"])
+        if url.endswith("/mcp"):
+            return "streamable_http"
+        if url.endswith("/sse"):
+            return "sse"
+        return "sse"
+
+    raise ValueError("Cannot detect transport: server config must have 'command' or 'url'.")
+
+
+@asynccontextmanager
+async def _create_session(config: dict):
+    transport = _detect_transport(config)
+
+    # mcp SDK is required for stdio/sse/streamable_http
+    try:
+        from mcp import ClientSession, StdioServerParameters  # type: ignore
+    except Exception:
+        _missing_dep("mcp")
+
+    if transport == "stdio":
+        from mcp.client.stdio import stdio_client  # type: ignore
+
+        env = {**os.environ}
+        if config_env := config.get("env"):
+            if isinstance(config_env, dict):
+                env.update({str(k): str(v) for k, v in config_env.items()})
+
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=env,
+            cwd=config.get("cwd"),
+        )
+
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "sse":
+        from mcp.client.sse import sse_client  # type: ignore
+
+        url = config["url"]
+        headers = dict(config.get("headers") or {})
+        # Prefer explicit headers, then api_key sugar, then stored OAuth token.
+        if "api_key" in config and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {config['api_key']}"
+        if "Authorization" not in headers and config.get("__server_name"):
+            tok = _oauth_maybe_refresh(str(config["__server_name"]), config)
+            if tok:
+                headers["Authorization"] = f"Bearer {tok}"
+        timeout = config.get("timeout", 30)
+
+        async with sse_client(url, headers=headers, timeout=timeout) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "streamable_http":
+        from mcp.client.streamable_http import streamablehttp_client  # type: ignore
+
+        url = config["url"]
+        headers = dict(config.get("headers") or {})
+        if "api_key" in config and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {config['api_key']}"
+        if "Authorization" not in headers and config.get("__server_name"):
+            tok = _oauth_maybe_refresh(str(config["__server_name"]), config)
+            if tok:
+                headers["Authorization"] = f"Bearer {tok}"
+        timeout = config.get("timeout", 30)
+
+        async with streamablehttp_client(url, headers=headers, timeout=timeout) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise ValueError(f"Unsupported transport: {transport}")
+
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+def _cmd_servers(servers: dict) -> list[dict]:
+    result: list[dict] = []
+    for name, config in servers.items():
+        try:
+            transport = _detect_transport(config)
+        except Exception as e:
+            result.append({"name": name, "error": str(e)})
+            continue
+
+        info: dict[str, Any] = {"name": name, "transport": transport}
+        if transport == "stdio":
+            info["command"] = config.get("command")
+        else:
+            info["url"] = config.get("url")
+        result.append(info)
+    return result
+
+
+async def _cmd_tools(servers: dict, server_name: str) -> list[dict]:
+    config = dict(_get_server_config(servers, server_name))
+    config["__server_name"] = server_name
+    async with _create_session(config) as session:
+        result = await session.list_tools()
+        tools: list[dict] = []
+        for tool in result.tools:
+            tools.append(
+                {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", None),
+                    "parameters": getattr(tool, "inputSchema", None),
+                }
+            )
+        return tools
+
+
+async def _cmd_call(servers: dict, server_name: str, tool_name: str, arguments: dict) -> Any:
+    config = dict(_get_server_config(servers, server_name))
+    config["__server_name"] = server_name
+    async with _create_session(config) as session:
+        result = await session.call_tool(tool_name, arguments)
+
+        # Extract content from result when possible (mcp SDK style).
+        if hasattr(result, "content"):
+            contents = []
+            for item in result.content:
+                if hasattr(item, "text"):
+                    contents.append(item.text)
+                elif hasattr(item, "data"):
+                    contents.append({"type": "data", "data": item.data})
+                else:
+                    contents.append(str(item))
+            return contents[0] if len(contents) == 1 else contents
+        return result
+
+
+# =============================================================================
+# CLI Interface
+# =============================================================================
+
+def _print_usage() -> None:
+    usage = """Usage: mcp_client.py <command> [args]
+
+Commands:
+  servers
+  tools <server>
+  call <server> <tool> '<json>'
+  auth <server>
+  token <server>
+  logout <server>
+
+Examples:
+  python mcp_client.py servers
+  python mcp_client.py tools sequential-thinking
+  python mcp_client.py call github search_repos '{"query":"python mcp"}'
+  python mcp_client.py auth some-remote-oauth-server
+
+Config sources (checked in order):
+  1. MCP_CONFIG_PATH (path to JSON)
+  2. MCP_CONFIG (inline JSON)
+  3. .mcp.json (current directory)
+  4. $ICA_HOME/mcp-servers.json (or $ICA_HOME/mcp.json)
+  5. references/mcp-config.json (next to this script)
+  6. ~/.claude.json"""
+    print(usage)
+
+
+async def main() -> None:
+    if len(sys.argv) < 2:
+        _print_usage()
+        raise SystemExit(1)
+
+    command = sys.argv[1].lower()
+    if command in ("--help", "-h", "help"):
+        _print_usage()
+        return
+
+    try:
+        servers = _load_servers()
+    except (FileNotFoundError, ValueError) as e:
+        _print_error(str(e), "configuration")
+        raise SystemExit(1)
+
+    try:
+        if command == "servers":
+            _print_json(_cmd_servers(servers))
+            return
+
+        if command == "tools":
+            if len(sys.argv) < 3:
+                _print_error("Usage: tools <server_name>", "usage")
+                raise SystemExit(1)
+            _print_json(await _cmd_tools(servers, sys.argv[2]))
+            return
+
+        if command == "call":
+            if len(sys.argv) < 4:
+                _print_error("Usage: call <server> <tool> [json_args]", "usage")
+                raise SystemExit(1)
+            args: dict[str, Any] = {}
+            if len(sys.argv) >= 5:
+                try:
+                    args = json.loads(sys.argv[4])
+                except json.JSONDecodeError as e:
+                    _print_error(f"Invalid JSON arguments: {e}", "invalid_args")
+                    raise SystemExit(1)
+            _print_json(await _cmd_call(servers, sys.argv[2], sys.argv[3], args))
+            return
+
+        if command == "auth":
+            if len(sys.argv) < 3:
+                _print_error("Usage: auth <server>", "usage")
+                raise SystemExit(1)
+            server_name = sys.argv[2]
+            cfg = _get_server_config(servers, server_name)
+            oauth = _resolve_oauth_config(cfg)
+            if not oauth:
+                _print_error("Server has no oauth configuration.", "configuration")
+                raise SystemExit(1)
+            typ = str(oauth.get("type") or "pkce").lower()
+            if "device" in typ:
+                _print_json(await _oauth_auth_device_code(server_name, cfg))
+                return
+            res = await _oauth_auth_pkce(server_name, cfg)
+            _print_json(res)
+            return
+
+        if command == "token":
+            if len(sys.argv) < 3:
+                _print_error("Usage: token <server>", "usage")
+                raise SystemExit(1)
+            server_name = sys.argv[2]
+            entry = _get_token_entry(server_name)
+            if not entry:
+                _print_json({"server": server_name, "status": "missing"})
+                return
+            _print_json(
+                {
+                    "server": server_name,
+                    "status": "present",
+                    "expires_at": entry.get("expires_at"),
+                    "expired": _token_is_expired(entry),
+                    "scope": entry.get("scope"),
+                    "token_type": entry.get("token_type"),
+                }
+            )
+            return
+
+        if command == "logout":
+            if len(sys.argv) < 3:
+                _print_error("Usage: logout <server>", "usage")
+                raise SystemExit(1)
+            server_name = sys.argv[2]
+            ok = _delete_token_entry(server_name)
+            _print_json({"server": server_name, "status": "deleted" if ok else "missing"})
+            return
+
+        _print_error(f"Unknown command: {command}", "usage")
+        _print_usage()
+        raise SystemExit(1)
+
+    except ValueError as e:
+        _print_error(str(e), "validation")
+        raise SystemExit(1)
+    except DependencyError as e:
+        _print_error(str(e), "dependency")
+        raise SystemExit(1)
+    except Exception as e:
+        _print_error(str(e), "error")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/skills/mcp-common/SKILL.md
+++ b/src/skills/mcp-common/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: mcp-common
+description: Internal shared helpers for ICA MCP tooling (client/proxy). Not intended to be invoked directly by users.
+---
+
+# MCP Common (Internal)
+
+Shared Python helpers used by ICA MCP tools:
+- `mcp-client`
+- `mcp-proxy`
+
+This skill is not meant to be invoked directly. It exists to keep `mcp-client` and `mcp-proxy` consistent and avoid copy/paste drift.
+

--- a/src/skills/mcp-common/scripts/ica_mcp_core.py
+++ b/src/skills/mcp-common/scripts/ica_mcp_core.py
@@ -1,0 +1,1139 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Core
+
+Shared building blocks for:
+- mcp-client (CLI)
+- mcp-proxy (local stdio MCP server that mirrors upstream tools)
+
+Responsibilities:
+- Load/merge MCP server definitions from:
+  - MCP_CONFIG (inline JSON) / MCP_CONFIG_PATH (single file override)
+  - project .mcp.json
+  - $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - ~/.claude.json fallback (compat only)
+- Expand ${ENV_VAR} placeholders
+- Token store under $ICA_HOME/mcp-tokens.json
+- OAuth flows:
+  - PKCE (explicit endpoints or OIDC discovery)
+  - Device code (explicit endpoints or OIDC discovery)
+  - Client credentials (explicit token endpoint)
+- Create MCP client sessions for stdio/sse/streamable_http
+
+This module is intentionally dependency-light (stdlib + `mcp` when used for sessions).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+import time
+import threading
+import urllib.parse
+import urllib.request
+import ipaddress
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from socketserver import TCPServer
+from typing import Any, Optional
+
+
+class DependencyError(RuntimeError):
+    pass
+
+
+def missing_dep(dep: str, extra: str = "") -> None:
+    hint = f"Missing dependency '{dep}'. Install it with: pip install {dep}"
+    if extra:
+        hint = f"{hint}. {extra}"
+    raise DependencyError(hint)
+
+
+# =============================================================================
+# ICA_HOME Resolution
+# =============================================================================
+
+def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
+    """
+    Resolve ICA_HOME (agent home directory).
+
+    Priority:
+    - ICA_HOME env var
+    - infer from installed skill layout: <ICA_HOME>/skills/<skill>/scripts/<file>.py
+    """
+    if os.environ.get("ICA_HOME"):
+        return Path(os.environ["ICA_HOME"]).expanduser()
+
+    if script_file:
+        p = Path(script_file).resolve()
+        # .../skills/<skill>/scripts/<file>
+        try:
+            if p.parents[2].name == "skills":
+                candidate = p.parents[3]
+                # Guard: avoid treating repo layout (src/skills/...) as ICA_HOME.
+                # Installed ICA homes include VERSION at the root.
+                if (candidate / "VERSION").exists():
+                    return candidate
+        except Exception:
+            return None
+
+    return None
+
+
+# =============================================================================
+# Config Loading / Merging
+# =============================================================================
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def expand_env_placeholders(value: Any) -> Any:
+    """
+    Best-effort `${VAR}` expansion for config values.
+    - Only expands when VAR is present in the process environment.
+    - Leaves unknown placeholders unchanged (so configs remain portable).
+    """
+    if isinstance(value, str):
+        def repl(match: re.Match) -> str:
+            name = match.group(1)
+            return os.environ.get(name, match.group(0))
+
+        return _ENV_VAR_PATTERN.sub(repl, value)
+
+    if isinstance(value, list):
+        return [expand_env_placeholders(v) for v in value]
+
+    if isinstance(value, dict):
+        return {k: expand_env_placeholders(v) for k, v in value.items()}
+
+    return value
+
+
+def _normalize_servers(config: dict) -> dict[str, dict[str, Any]]:
+    servers = config.get("mcpServers", config)
+    if not isinstance(servers, dict):
+        raise ValueError("Config must be an object or contain an 'mcpServers' object.")
+
+    filtered: dict[str, dict[str, Any]] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if "command" in cfg or "url" in cfg:
+            filtered[str(name)] = cfg
+    return filtered
+
+
+def _read_json_file(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _project_mcp_path(cwd: Optional[Path] = None) -> Path:
+    return (cwd or Path.cwd()) / ".mcp.json"
+
+
+def _ica_mcp_paths(ica_home: Optional[Path]) -> list[Path]:
+    if not ica_home:
+        return []
+    return [ica_home / "mcp-servers.json", ica_home / "mcp.json"]
+
+
+@dataclass(frozen=True)
+class LoadedServers:
+    servers: dict[str, dict[str, Any]]
+    sources: list[str]
+    server_sources: dict[str, str]
+    blocked_servers: dict[str, str]
+    project_root: Optional[str] = None
+    project_mcp_sha256: Optional[str] = None
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name) in ("1", "true", "TRUE", "yes", "YES", "on", "ON")
+
+
+def trust_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    if os.environ.get("ICA_MCP_TRUST_PATH"):
+        return Path(os.environ["ICA_MCP_TRUST_PATH"]).expanduser()
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-trust.json"
+
+
+def load_trust_store(*, script_file: Optional[str] = None) -> dict:
+    path = trust_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "projects": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "projects": {}}
+        if not isinstance(data.get("projects"), dict):
+            return {"version": 1, "projects": {}}
+        return data
+    except Exception:
+        return {"version": 1, "projects": {}}
+
+
+def save_trust_store(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = trust_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store trust state (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def project_mcp_sha256(project_root: Path) -> Optional[str]:
+    p = project_root / ".mcp.json"
+    if not p.exists():
+        return None
+    try:
+        raw = p.read_bytes()
+        return hashlib.sha256(raw).hexdigest()
+    except Exception:
+        return None
+
+
+def get_project_trust_status(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    current_hash = project_mcp_sha256(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    entry = (data.get("projects") or {}).get(root)
+
+    if not entry:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project is not trusted for strict project stdio execution.",
+            "current_mcp_sha256": current_hash,
+        }
+
+    trusted_hash = entry.get("mcp_sha256")
+    if current_hash and trusted_hash and current_hash != trusted_hash:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project .mcp.json changed since trust was granted.",
+            "current_mcp_sha256": current_hash,
+            "trusted_mcp_sha256": trusted_hash,
+            "trusted_at": entry.get("trusted_at"),
+        }
+
+    return {
+        "project": root,
+        "trusted": True,
+        "reason": "Trusted.",
+        "current_mcp_sha256": current_hash,
+        "trusted_mcp_sha256": trusted_hash,
+        "trusted_at": entry.get("trusted_at"),
+    }
+
+
+def trust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    projects[root] = {
+        "mcp_sha256": project_mcp_sha256(project_root.resolve()),
+        "trusted_at": int(time.time()),
+    }
+    save_trust_store(data, script_file=script_file)
+    return get_project_trust_status(project_root.resolve(), script_file=script_file)
+
+
+def untrust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> bool:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    if root in projects:
+        del projects[root]
+        save_trust_store(data, script_file=script_file)
+        return True
+    return False
+
+
+def load_servers_merged(
+    *,
+    script_file: Optional[str] = None,
+    cwd: Optional[Path] = None,
+) -> LoadedServers:
+    """
+    Load upstream server definitions.
+
+    Override modes:
+    - MCP_CONFIG (inline JSON) => only this, no merge
+    - MCP_CONFIG_PATH (path)   => only this, no merge
+
+    Default merge:
+    - project .mcp.json
+    - ICA_HOME mcp-servers.json/mcp.json
+    - (fallback) ~/.claude.json if neither exists
+
+    Precedence default: project overrides ICA_HOME.
+    Set ICA_MCP_CONFIG_PREFER_HOME=1 to flip.
+    """
+    sources: list[str] = []
+    server_sources: dict[str, str] = {}
+    blocked_servers: dict[str, str] = {}
+    current_cwd = (cwd or Path.cwd()).resolve()
+
+    # Inline JSON override
+    if env_config := os.environ.get("MCP_CONFIG"):
+        cfg = json.loads(env_config)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=["env:MCP_CONFIG"],
+            server_sources={k: "env" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    # File override
+    if env_path := os.environ.get("MCP_CONFIG_PATH"):
+        p = Path(env_path).expanduser()
+        cfg = _read_json_file(p)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=[f"file:{str(p)}"],
+            server_sources={k: "env_file" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    merged: dict[str, dict[str, Any]] = {}
+
+    ica_home = get_ica_home(script_file=script_file)
+    project_path = _project_mcp_path(cwd=cwd)
+    home_paths = _ica_mcp_paths(ica_home)
+
+    prefer_home = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME") in ("1", "true", "TRUE", "yes", "YES")
+
+    # Load layers (if present)
+    project_servers: dict[str, dict[str, Any]] = {}
+    home_servers: dict[str, dict[str, Any]] = {}
+
+    if project_path.exists():
+        project_servers = _normalize_servers(_read_json_file(project_path))
+        sources.append(f"file:{str(project_path)}")
+
+    for hp in home_paths:
+        if hp.exists():
+            home_servers = _normalize_servers(_read_json_file(hp))
+            sources.append(f"file:{str(hp)}")
+            break
+
+    # Fallback (compat only) if nothing else exists
+    if not project_servers and not home_servers:
+        claude = Path.home() / ".claude.json"
+        if claude.exists():
+            home_servers = _normalize_servers(_read_json_file(claude))
+            sources.append(f"file:{str(claude)}")
+
+    if prefer_home:
+        merge_layers = [("project", project_servers), ("home", home_servers)]
+    else:
+        merge_layers = [("home", home_servers), ("project", project_servers)]
+
+    for src_name, layer in merge_layers:
+        for name, cfg in layer.items():
+            merged[name] = cfg
+            server_sources[name] = src_name
+
+    strict_trust = _env_truthy("ICA_MCP_STRICT_TRUST")
+    allow_project_stdio = _env_truthy("ICA_MCP_ALLOW_PROJECT_STDIO")
+    project_root_path = project_path.parent.resolve()
+    project_hash = project_mcp_sha256(project_root_path)
+
+    if strict_trust and project_servers:
+        trusted_status = get_project_trust_status(project_root_path, script_file=script_file)
+        project_trusted = allow_project_stdio or bool(trusted_status.get("trusted"))
+
+        filtered: dict[str, dict[str, Any]] = {}
+        for name, cfg in merged.items():
+            if server_sources.get(name) == "project" and "command" in cfg and not project_trusted:
+                reason = trusted_status.get("reason") or "Project stdio server is not trusted."
+                blocked_servers[name] = reason
+                continue
+            filtered[name] = cfg
+        merged = filtered
+
+    return LoadedServers(
+        servers=expand_env_placeholders(merged),
+        sources=sources,
+        server_sources=server_sources,
+        blocked_servers=blocked_servers,
+        project_root=str(project_root_path),
+        project_mcp_sha256=project_hash,
+    )
+
+
+# =============================================================================
+# Token Store
+# =============================================================================
+
+def tokens_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-tokens.json"
+
+
+def load_tokens(*, script_file: Optional[str] = None) -> dict:
+    path = tokens_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "servers": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "servers": {}}
+        if "servers" not in data or not isinstance(data.get("servers"), dict):
+            return {"version": 1, "servers": {}}
+        return data
+    except Exception:
+        return {"version": 1, "servers": {}}
+
+
+def save_tokens(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = tokens_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def get_token_entry(server_name: str, *, script_file: Optional[str] = None) -> Optional[dict]:
+    data = load_tokens(script_file=script_file)
+    return data.get("servers", {}).get(server_name)
+
+
+def set_token_entry(server_name: str, entry: dict, *, script_file: Optional[str] = None) -> None:
+    data = load_tokens(script_file=script_file)
+    data.setdefault("servers", {})[server_name] = entry
+    save_tokens(data, script_file=script_file)
+
+
+def delete_token_entry(server_name: str, *, script_file: Optional[str] = None) -> bool:
+    data = load_tokens(script_file=script_file)
+    servers = data.setdefault("servers", {})
+    if server_name in servers:
+        del servers[server_name]
+        save_tokens(data, script_file=script_file)
+        return True
+    return False
+
+
+def token_is_expired(entry: dict, skew_seconds: int = 30) -> bool:
+    expires_at = entry.get("expires_at")
+    if not expires_at:
+        return False
+    try:
+        return time.time() >= float(expires_at) - skew_seconds
+    except Exception:
+        return False
+
+
+# =============================================================================
+# HTTP Helpers
+# =============================================================================
+
+def _http_json_get(url: str, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _http_form_post(url: str, data: dict, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    encoded = urllib.parse.urlencode({k: v for k, v in data.items() if v is not None}).encode("utf-8")
+    hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
+    req = urllib.request.Request(url, data=encoded, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return bool(ip.is_loopback)
+    except ValueError:
+        return False
+
+
+def _validate_secure_url(url: str, *, field: str, allow_http_loopback: bool = False) -> None:
+    parsed = urllib.parse.urlparse(str(url))
+    scheme = (parsed.scheme or "").lower()
+    host = parsed.hostname
+
+    if scheme == "https":
+        return
+    if allow_http_loopback and scheme == "http" and _is_loopback_host(host):
+        return
+    raise ValueError(
+        f"{field} must use https (or http only for localhost/loopback during local development)."
+    )
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)[:96]
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# =============================================================================
+# OAuth
+# =============================================================================
+
+def resolve_oauth_config(server_cfg: dict) -> Optional[dict]:
+    oauth = server_cfg.get("oauth")
+    if not oauth or not isinstance(oauth, dict):
+        return None
+    return oauth
+
+
+def resolve_oauth_endpoints(oauth: dict) -> dict:
+    typ = str(oauth.get("type") or "pkce").lower()
+    if typ.startswith("oidc"):
+        issuer = oauth.get("issuer")
+        if not issuer:
+            raise ValueError("oauth.issuer is required for OIDC flows.")
+        _validate_secure_url(str(issuer), field="oauth.issuer", allow_http_loopback=True)
+        well_known = str(issuer).rstrip("/") + "/.well-known/openid-configuration"
+        cfg = _http_json_get(well_known, timeout=int(oauth.get("token_timeout", 30)))
+        return {
+            "authorization_url": cfg.get("authorization_endpoint"),
+            "token_url": cfg.get("token_endpoint"),
+            "device_authorization_url": cfg.get("device_authorization_endpoint"),
+        }
+    return {
+        "authorization_url": oauth.get("authorization_url"),
+        "token_url": oauth.get("token_url"),
+        "device_authorization_url": oauth.get("device_authorization_url"),
+    }
+
+
+class _OAuthRedirectHandler(BaseHTTPRequestHandler):
+    _event: threading.Event
+    _state: str
+    _result: dict
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        qs = urllib.parse.parse_qs(parsed.query)
+        code = (qs.get("code") or [None])[0]
+        state = (qs.get("state") or [None])[0]
+        err = (qs.get("error") or [None])[0]
+        desc = (qs.get("error_description") or [None])[0]
+
+        ok = code and state == self._state and not err
+        if ok:
+            self._result.update({"code": code, "state": state})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication complete. You can close this tab.\n")
+        else:
+            self._result.update({"error": err or "invalid_redirect", "error_description": desc, "state": state})
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication failed. Return to the terminal.\n")
+
+        self._event.set()
+
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+
+async def oauth_auth_pkce(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    flow_override: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    auth_url = endpoints.get("authorization_url")
+    token_url = endpoints.get("token_url")
+    if not auth_url or not token_url:
+        raise ValueError("OAuth PKCE requires authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(auth_url), field="oauth.authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    redirect_uri = oauth.get("redirect_uri") or "http://127.0.0.1:8765/callback"
+    parsed = urllib.parse.urlparse(str(redirect_uri))
+    if parsed.scheme not in ("http",):
+        raise ValueError("oauth.redirect_uri must be an http:// localhost URL.")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8765
+    if not _is_loopback_host(host):
+        raise ValueError("oauth.redirect_uri host must be localhost or a loopback IP.")
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    extra_auth_params = oauth.get("extra_auth_params") or {}
+    if not isinstance(extra_auth_params, dict):
+        raise ValueError("oauth.extra_auth_params must be an object.")
+
+    params = {
+        "response_type": "code",
+        "client_id": str(client_id),
+        "redirect_uri": str(redirect_uri),
+        "scope": " ".join([str(s) for s in scopes]),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        **{str(k): str(v) for k, v in extra_auth_params.items()},
+    }
+    url = str(auth_url) + ("&" if "?" in str(auth_url) else "?") + urllib.parse.urlencode(params)
+
+    event = threading.Event()
+    result: dict[str, Any] = {}
+
+    def handler_factory(*_args, **_kwargs):
+        h = _OAuthRedirectHandler(*_args, **_kwargs)
+        h._event = event
+        h._state = state
+        h._result = result
+        return h
+
+    httpd = TCPServer((host, port), handler_factory)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        try:
+            import webbrowser
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+        if not event.wait(timeout=int(oauth.get("timeout", 300))):
+            raise TimeoutError("Timed out waiting for OAuth redirect.")
+
+        if "code" not in result:
+            raise ValueError(
+                f"OAuth redirect error: {result.get('error')} {result.get('error_description') or ''}".strip()
+            )
+
+        code = result["code"]
+
+        extra_token_params = oauth.get("extra_token_params") or {}
+        if not isinstance(extra_token_params, dict):
+            raise ValueError("oauth.extra_token_params must be an object.")
+
+        token_req = {
+            "grant_type": "authorization_code",
+            "client_id": str(client_id),
+            "code": code,
+            "redirect_uri": str(redirect_uri),
+            "code_verifier": verifier,
+            **{str(k): str(v) for k, v in extra_token_params.items()},
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+        access = token.get("access_token")
+        if not access:
+            raise ValueError("Token response missing access_token.")
+
+        expires_at = None
+        try:
+            if token.get("expires_in") is not None:
+                expires_at = int(time.time()) + int(token["expires_in"])
+        except Exception:
+            expires_at = None
+
+        entry = {
+            "access_token": access,
+            "refresh_token": token.get("refresh_token"),
+            "token_type": token.get("token_type") or "Bearer",
+            "scope": token.get("scope"),
+            "expires_at": expires_at,
+            "obtained_at": int(time.time()),
+        }
+        set_token_entry(server_name, entry, script_file=script_file)
+        return {"status": "ok", "server": server_name, "auth_url": url, "saved_to": str(tokens_path(script_file=script_file) or "")}
+    finally:
+        try:
+            httpd.shutdown()
+            httpd.server_close()
+        except Exception:
+            pass
+
+
+async def oauth_auth_device_code(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    device_url = endpoints.get("device_authorization_url")
+    token_url = endpoints.get("token_url")
+    if not device_url or not token_url:
+        raise ValueError("OAuth device code requires device_authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(device_url), field="oauth.device_authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    req = {"client_id": str(client_id), "scope": " ".join([str(s) for s in scopes])}
+    device = _http_form_post(str(device_url), req, timeout=int(oauth.get("token_timeout", 30)))
+    device_code = device.get("device_code")
+    user_code = device.get("user_code")
+    verify_uri = device.get("verification_uri") or device.get("verification_uri_complete")
+    interval = int(device.get("interval") or 5)
+    expires_in = int(device.get("expires_in") or 600)
+
+    if not device_code or not user_code or not verify_uri:
+        raise ValueError("Device code response missing required fields.")
+
+    instructions = {
+        "verification_uri": device.get("verification_uri"),
+        "verification_uri_complete": device.get("verification_uri_complete"),
+        "user_code": user_code,
+        "expires_in": expires_in,
+        "interval": interval,
+    }
+
+    deadline = int(time.time()) + expires_in
+    while int(time.time()) < deadline:
+        token_req = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": str(client_id),
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+        if token.get("access_token"):
+            access = token["access_token"]
+            expires_at = None
+            try:
+                if token.get("expires_in") is not None:
+                    expires_at = int(time.time()) + int(token["expires_in"])
+            except Exception:
+                expires_at = None
+            entry = {
+                "access_token": access,
+                "refresh_token": token.get("refresh_token"),
+                "token_type": token.get("token_type") or "Bearer",
+                "scope": token.get("scope"),
+                "expires_at": expires_at,
+                "obtained_at": int(time.time()),
+            }
+            set_token_entry(server_name, entry, script_file=script_file)
+            return {
+                "status": "ok",
+                "server": server_name,
+                "saved_to": str(tokens_path(script_file=script_file) or ""),
+                "device": instructions,
+            }
+
+        err = token.get("error")
+        if err == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if err == "slow_down":
+            interval += 2
+            time.sleep(interval)
+            continue
+        raise ValueError(f"Device code auth failed: {err or 'unknown_error'}")
+
+    raise TimeoutError("Device code flow timed out.")
+
+
+async def oauth_auth_client_credentials(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        raise ValueError("client_credentials flow requires oauth.token_url (or OIDC issuer providing token_endpoint).")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        raise ValueError("client_credentials flow requires oauth.client_id and oauth.client_secret.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        raise ValueError("oauth.extra_token_params must be an object.")
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+    access = token.get("access_token")
+    if not access:
+        raise ValueError("Token response missing access_token.")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return {"status": "ok", "server": server_name, "saved_to": str(tokens_path(script_file=script_file) or "")}
+
+
+def _mint_client_credentials_token(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    """
+    Synchronous client-credentials mint, used for automatic refresh during header injection.
+    """
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return None
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        return None
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        return None
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        return None
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        return None
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return None
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+def oauth_maybe_refresh(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    entry = get_token_entry(server_name, script_file=script_file)
+    if not entry or not isinstance(entry, dict):
+        return None
+
+    if not token_is_expired(entry):
+        return entry.get("access_token")
+
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return entry.get("access_token")
+
+    # If client credentials, mint again (no refresh token needed).
+    if str(oauth.get("type") or "").lower() == "client_credentials":
+        minted = _mint_client_credentials_token(server_name, server_cfg, script_file=script_file)
+        return minted or entry.get("access_token")
+
+    refresh = entry.get("refresh_token")
+    if not refresh:
+        return entry.get("access_token")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    client_id = oauth.get("client_id")
+    if not token_url or not client_id:
+        return entry.get("access_token")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    token_req = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": str(client_id),
+    }
+    if oauth.get("client_secret"):
+        token_req["client_secret"] = str(oauth["client_secret"])
+
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return entry.get("access_token")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry["access_token"] = access
+    if token.get("refresh_token"):
+        entry["refresh_token"] = token.get("refresh_token")
+    entry["token_type"] = token.get("token_type") or entry.get("token_type") or "Bearer"
+    entry["scope"] = token.get("scope") or entry.get("scope")
+    entry["expires_at"] = expires_at
+    entry["obtained_at"] = int(time.time())
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+# =============================================================================
+# Transport / Session (Client)
+# =============================================================================
+
+def detect_transport(config: dict) -> str:
+    if explicit_type := config.get("type"):
+        type_map = {
+            "stdio": "stdio",
+            "sse": "sse",
+            "http": "streamable_http",
+            "streamable_http": "streamable_http",
+            "streamable-http": "streamable_http",
+        }
+        return type_map.get(str(explicit_type).lower(), str(explicit_type).lower())
+
+    if "command" in config:
+        return "stdio"
+
+    if "url" in config:
+        url = str(config["url"])
+        if url.endswith("/mcp"):
+            return "streamable_http"
+        if url.endswith("/sse"):
+            return "sse"
+        return "sse"
+
+    raise ValueError("Cannot detect transport: server config must have 'command' or 'url'.")
+
+
+def build_auth_headers(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    force_refresh: bool = False,
+) -> dict:
+    headers = dict(server_cfg.get("headers") or {})
+
+    # Explicit header always wins.
+    if "Authorization" in headers:
+        return headers
+
+    if "api_key" in server_cfg:
+        headers["Authorization"] = f"Bearer {server_cfg['api_key']}"
+        return headers
+
+    tok = oauth_maybe_refresh(server_name, server_cfg, script_file=script_file)
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    return headers
+
+
+@asynccontextmanager
+async def create_session(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None):
+    transport = detect_transport(server_cfg)
+
+    try:
+        from mcp import ClientSession, StdioServerParameters  # type: ignore
+    except Exception:
+        missing_dep("mcp")
+
+    if transport == "stdio":
+        from mcp.client.stdio import stdio_client  # type: ignore
+
+        env = {**os.environ}
+        if cfg_env := server_cfg.get("env"):
+            if isinstance(cfg_env, dict):
+                env.update({str(k): str(v) for k, v in cfg_env.items()})
+
+        params = StdioServerParameters(
+            command=server_cfg["command"],
+            args=server_cfg.get("args", []),
+            env=env,
+            cwd=server_cfg.get("cwd"),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "sse":
+        from mcp.client.sse import sse_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with sse_client(url, headers=headers, timeout=timeout) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "streamable_http":
+        from mcp.client.streamable_http import streamablehttp_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with streamablehttp_client(url, headers=headers, timeout=timeout) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise ValueError(f"Unsupported transport: {transport}")

--- a/src/skills/mcp-proxy/SKILL.md
+++ b/src/skills/mcp-proxy/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: mcp-proxy
+description: Local stdio MCP proxy server that mirrors upstream MCP servers/tools and centralizes authentication (OAuth, headers/env). Register one server in your agent runtime, manage upstreams via .mcp.json and/or $ICA_HOME/mcp-servers.json.
+---
+
+# MCP Proxy (ICA-Owned)
+
+Register a single MCP server (`ica-mcp-proxy`) in your agent runtime. The proxy:
+- reads upstream server definitions from `.mcp.json` (project) and `$ICA_HOME/mcp-servers.json` (user)
+- mirrors upstream tools as proxy tools named `<server>.<tool>`
+- provides stable broker tools under `proxy.*` so clients can always list/call even when mirroring is truncated
+- runs OAuth flows and caches tokens under `$ICA_HOME/mcp-tokens.json`
+
+## Install / Dependencies
+
+Python 3.9+ and:
+
+```bash
+pip install mcp anyio jsonschema
+```
+
+## Configure Upstreams
+
+Create `.mcp.json` in your project and/or `$ICA_HOME/mcp-servers.json`:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "remote-example": {
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer ${REMOTE_API_KEY}" }
+    }
+  }
+}
+```
+
+Precedence:
+- default: project `.mcp.json` overrides `$ICA_HOME/mcp-servers.json`
+- set `ICA_MCP_CONFIG_PREFER_HOME=1` to flip
+
+## Register The Proxy In Your Tool
+
+Example MCP stdio server entry:
+
+```json
+{
+  "ica-mcp-proxy": {
+    "command": "python",
+    "args": ["<ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_server.py"]
+  }
+}
+```
+
+For runtime-specific copy/paste snippets (Codex, Cursor, Gemini CLI, OpenCode, Antigravity), see:
+
+- `docs/mcp-proxy.md` -> `Multi-Agent Registration Snippets`
+- `docs/mcp-proxy.md` -> `Project Trust Gate (Optional)` for strict-mode greenlighting
+
+## Broker Tools (Always Available)
+
+- `proxy.list_servers()`
+- `proxy.list_tools(server, include_schema?)`
+- `proxy.call(server, tool, args)`
+- `proxy.mirror_status()`
+- `proxy.auth_start(server, flow?)`
+- `proxy.auth_status(server)`
+- `proxy.auth_refresh(server)`
+- `proxy.auth_logout(server)`
+
+Auth trigger behavior:
+- Use `proxy.auth_start(server, flow?)` to initiate login.
+- PKCE flow launches/open browser best-effort and waits on localhost callback.
+- Device code flow returns `verification_uri` + `user_code` instructions.
+- `proxy.auth_refresh` rotates/refreshes credentials; `proxy.auth_logout` deletes them.
+- OAuth endpoints should use `https://` (localhost `http://` is allowed for local development only).
+- PKCE redirect URI host must be localhost/loopback.
+
+## Mirrored Tools
+
+Upstream tools appear as tools named:
+
+`<server>.<tool>`
+
+Example:
+- `sequential-thinking.sequentialthinking`
+
+## Guardrails (Mirroring Limits)
+
+Set env vars to avoid tool/schema explosions:
+
+- `ICA_MCP_PROXY_MAX_SERVERS` (default: 25)
+- `ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER` (default: 200)
+- `ICA_MCP_PROXY_MAX_TOTAL_TOOLS` (default: 2000)
+- `ICA_MCP_PROXY_MAX_SCHEMA_BYTES` (default: 65536)
+- `ICA_MCP_PROXY_TOOL_CACHE_TTL_S` (default: 300)
+
+When limits are exceeded, `proxy.*` broker tools remain available, and `proxy.mirror_status()` explains truncation.
+
+## Stdio Pooling (Lifecycle-Safe)
+
+For `stdio` upstreams, the proxy uses a dedicated worker task per upstream to keep session open/reused safely across calls while preserving AnyIO task/cancel-scope ownership.
+
+Environment controls:
+- `ICA_MCP_PROXY_POOL_STDIO` (default: `true`)
+- `ICA_MCP_PROXY_DISABLE_POOLING` (default: `false`)
+- `ICA_MCP_PROXY_UPSTREAM_IDLE_TTL_S` (default: `90`)
+- `ICA_MCP_PROXY_UPSTREAM_REQUEST_TIMEOUT_S` (default: `120`)
+
+If credentials are updated via auth tools, the proxy recycles pooled upstream sessions so new tokens/headers are applied.

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Proxy CLI (helper)
+
+This is optional, but useful for debugging without involving an agent runtime.
+
+Commands:
+  servers
+  trust [project_path]
+  trust-status [project_path]
+  untrust [project_path]
+  mirror-status
+  token <server>
+  logout <server>
+
+Notes:
+  - Trust commands are used with ICA_MCP_STRICT_TRUST=1.
+  - `trust` stores trust in $ICA_HOME/mcp-trust.json (or ICA_MCP_TRUST_PATH).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _import_core():
+    here = Path(__file__).resolve()
+    skills_dir = here.parents[2]
+    common = skills_dir / "mcp-common" / "scripts"
+    if common.exists():
+        import sys as _sys
+
+        _sys.path.insert(0, str(common))
+    from ica_mcp_core import (  # type: ignore
+        delete_token_entry,
+        get_project_trust_status,
+        get_token_entry,
+        load_servers_merged,
+        token_is_expired,
+        trust_path,
+        trust_project,
+        untrust_project,
+    )
+
+    return (
+        delete_token_entry,
+        get_project_trust_status,
+        get_token_entry,
+        load_servers_merged,
+        token_is_expired,
+        trust_path,
+        trust_project,
+        untrust_project,
+    )
+
+
+(
+    delete_token_entry,
+    get_project_trust_status,
+    get_token_entry,
+    load_servers_merged,
+    token_is_expired,
+    trust_path,
+    trust_project,
+    untrust_project,
+) = _import_core()
+
+
+def _print(data):
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _project_from_argv() -> Path:
+    if len(sys.argv) >= 3:
+        return Path(sys.argv[2]).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name) in ("1", "true", "TRUE", "yes", "YES", "on", "ON")
+
+
+async def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
+        print(__doc__.strip())
+        raise SystemExit(0)
+
+    cmd = sys.argv[1]
+
+    if cmd == "servers":
+        loaded = load_servers_merged(script_file=__file__)
+        _print(
+            {
+                "servers": sorted(loaded.servers.keys()),
+                "sources": loaded.sources,
+                "blocked_servers": getattr(loaded, "blocked_servers", {}),
+                "strict_trust": _env_truthy("ICA_MCP_STRICT_TRUST"),
+            }
+        )
+        return
+
+    if cmd == "mirror-status":
+        loaded = load_servers_merged(script_file=__file__)
+        _print(
+            {
+                "note": "Static preview only. Use proxy.mirror_status from an MCP client for runtime mirror details.",
+                "servers_configured": sorted(loaded.servers.keys()),
+                "blocked_servers": getattr(loaded, "blocked_servers", {}),
+            }
+        )
+        return
+
+    if cmd == "trust":
+        project = _project_from_argv()
+        out = trust_project(project, script_file=__file__)
+        out["trust_store"] = str(trust_path(script_file=__file__) or "")
+        _print(out)
+        return
+
+    if cmd == "trust-status":
+        project = _project_from_argv()
+        out = get_project_trust_status(project, script_file=__file__)
+        out["trust_store"] = str(trust_path(script_file=__file__) or "")
+        _print(out)
+        return
+
+    if cmd == "untrust":
+        project = _project_from_argv()
+        ok = untrust_project(project, script_file=__file__)
+        _print(
+            {
+                "project": str(project),
+                "status": "removed" if ok else "missing",
+                "trust_store": str(trust_path(script_file=__file__) or ""),
+            }
+        )
+        return
+
+    if cmd == "token":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: token <server>")
+        s = sys.argv[2]
+        entry = get_token_entry(s, script_file=__file__)
+        if not entry:
+            _print({"server": s, "status": "missing"})
+            return
+        _print(
+            {
+                "server": s,
+                "status": "present",
+                "expired": token_is_expired(entry),
+                "expires_at": entry.get("expires_at"),
+                "scope": entry.get("scope"),
+                "token_type": entry.get("token_type"),
+            }
+        )
+        return
+
+    if cmd == "logout":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: logout <server>")
+        s = sys.argv[2]
+        ok = delete_token_entry(s, script_file=__file__)
+        _print({"server": s, "status": "deleted" if ok else "missing"})
+        return
+
+    raise SystemExit(f"Unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Proxy Server (stdio)
+
+Implements a local MCP server that:
+- loads upstream MCP servers from .mcp.json and/or $ICA_HOME/mcp-servers.json
+- mirrors upstream tools as proxy tools: "<server>.<tool>"
+- provides stable broker tools under "proxy.*"
+- manages OAuth + token caching in $ICA_HOME/mcp-tokens.json
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import os
+import re
+import time
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _import_core():
+    # Resolve <ICA_HOME>/skills/mcp-common/scripts for installed setups
+    here = Path(__file__).resolve()
+    skills_dir = here.parents[2]  # .../skills
+    common = skills_dir / "mcp-common" / "scripts"
+    if common.exists():
+        import sys
+
+        sys.path.insert(0, str(common))
+    try:
+        from ica_mcp_core import (  # type: ignore
+            DependencyError,
+            create_session,
+            delete_token_entry,
+            detect_transport,
+            get_token_entry,
+            load_servers_merged,
+            oauth_auth_client_credentials,
+            oauth_auth_device_code,
+            oauth_auth_pkce,
+            oauth_maybe_refresh,
+            resolve_oauth_config,
+            set_token_entry,
+            token_is_expired,
+            tokens_path,
+        )
+
+        return {
+            "DependencyError": DependencyError,
+            "create_session": create_session,
+            "delete_token_entry": delete_token_entry,
+            "detect_transport": detect_transport,
+            "get_token_entry": get_token_entry,
+            "load_servers_merged": load_servers_merged,
+            "oauth_auth_client_credentials": oauth_auth_client_credentials,
+            "oauth_auth_device_code": oauth_auth_device_code,
+            "oauth_auth_pkce": oauth_auth_pkce,
+            "oauth_maybe_refresh": oauth_maybe_refresh,
+            "resolve_oauth_config": resolve_oauth_config,
+            "set_token_entry": set_token_entry,
+            "token_is_expired": token_is_expired,
+            "tokens_path": tokens_path,
+        }
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to import ICA MCP core. Ensure mcp-common is installed alongside mcp-proxy."
+        ) from e
+
+
+core = _import_core()
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    return str(v).strip().lower() in ("1", "true", "yes", "on")
+
+
+_NAME_OK = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _sanitize(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", s)
+
+
+def _schema_size(schema: Any) -> int:
+    try:
+        return len(json.dumps(schema, separators=(",", ":"), default=str).encode("utf-8"))
+    except Exception:
+        return 0
+
+
+def _config_fingerprint(cfg: dict[str, Any]) -> str:
+    try:
+        raw = json.dumps(cfg, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    except Exception:
+        raw = repr(cfg).encode("utf-8", errors="replace")
+    return hashlib.sha1(raw).hexdigest()
+
+
+@dataclass
+class MirrorStatus:
+    sources: list[str]
+    servers_total: int
+    servers_mirrored: int
+    tools_total: int
+    tools_mirrored: int
+    truncated: bool
+    reasons: list[str]
+    blocked_servers: dict[str, str]
+
+
+@dataclass
+class _WorkerRequest:
+    op: str
+    tool_name: Optional[str] = None
+    args: Optional[dict[str, Any]] = None
+    future: Optional[asyncio.Future] = None
+
+
+class UpstreamWorker:
+    """
+    Owns one upstream stdio MCP session in a dedicated task.
+
+    This avoids AnyIO cancel-scope lifecycle mismatches by ensuring session
+    enter/use/exit all happen in the same task.
+    """
+
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        server_cfg: dict[str, Any],
+        idle_ttl_s: float,
+        request_timeout_s: float,
+        script_file: str,
+    ):
+        self.server_name = server_name
+        self.server_cfg = server_cfg
+        self.config_fingerprint = _config_fingerprint(server_cfg)
+        self.idle_ttl_s = idle_ttl_s
+        self.request_timeout_s = request_timeout_s
+        self.script_file = script_file
+
+        self._queue: asyncio.Queue[_WorkerRequest] = asyncio.Queue()
+        self._task: Optional[asyncio.Task] = None
+        self._start_lock = asyncio.Lock()
+
+    async def ensure_started(self) -> None:
+        if self._task and not self._task.done():
+            return
+        async with self._start_lock:
+            if self._task and not self._task.done():
+                return
+            self._task = asyncio.create_task(
+                self._run(),
+                name=f"ica-mcp-worker:{self.server_name}",
+            )
+
+    async def list_tools(self) -> Any:
+        return await self._request("list_tools")
+
+    async def call_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
+        return await self._request("call_tool", tool_name=tool_name, args=args)
+
+    async def _request(
+        self,
+        op: str,
+        *,
+        tool_name: Optional[str] = None,
+        args: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        await self.ensure_started()
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        await self._queue.put(_WorkerRequest(op=op, tool_name=tool_name, args=args, future=fut))
+        if self.request_timeout_s > 0:
+            return await asyncio.wait_for(fut, timeout=self.request_timeout_s)
+        return await fut
+
+    async def shutdown(self) -> None:
+        task = self._task
+        if not task:
+            return
+
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        try:
+            await self._queue.put(_WorkerRequest(op="shutdown", future=fut))
+            try:
+                await asyncio.wait_for(fut, timeout=5)
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except asyncio.TimeoutError:
+                task.cancel()
+                with contextlib.suppress(Exception):
+                    await task
+        finally:
+            self._task = None
+
+    async def _run(self) -> None:
+        stack = AsyncExitStack()
+        session: Any = None
+        try:
+            while True:
+                try:
+                    if self.idle_ttl_s > 0:
+                        req = await asyncio.wait_for(self._queue.get(), timeout=self.idle_ttl_s)
+                    else:
+                        req = await self._queue.get()
+                except asyncio.TimeoutError:
+                    # Idle timeout: recycle upstream session to release resources.
+                    if session is not None:
+                        with contextlib.suppress(Exception):
+                            await stack.aclose()
+                        stack = AsyncExitStack()
+                        session = None
+                    continue
+
+                if req.op == "shutdown":
+                    if req.future and not req.future.done():
+                        req.future.set_result({"status": "ok"})
+                    break
+
+                try:
+                    if session is None:
+                        ctx = core["create_session"](
+                            self.server_name, self.server_cfg, script_file=self.script_file
+                        )
+                        session = await stack.enter_async_context(ctx)
+
+                    if req.op == "list_tools":
+                        result = await session.list_tools()
+                    elif req.op == "call_tool":
+                        result = await session.call_tool(req.tool_name, req.args or {})
+                    else:
+                        raise ValueError(f"Unknown worker operation: {req.op}")
+
+                    if req.future and not req.future.done():
+                        req.future.set_result(result)
+                except Exception as exc:
+                    # Reset session on failures to avoid stale/broken state.
+                    with contextlib.suppress(Exception):
+                        await stack.aclose()
+                    stack = AsyncExitStack()
+                    session = None
+                    if req.future and not req.future.done():
+                        req.future.set_exception(exc)
+        finally:
+            with contextlib.suppress(Exception):
+                await stack.aclose()
+
+
+class ProxyRuntime:
+    def __init__(self):
+        self._tools_cache_ttl_s = _env_float("ICA_MCP_PROXY_TOOL_CACHE_TTL_S", 300)
+        self._max_servers = _env_int("ICA_MCP_PROXY_MAX_SERVERS", 25)
+        self._max_tools_per_server = _env_int("ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER", 200)
+        self._max_total_tools = _env_int("ICA_MCP_PROXY_MAX_TOTAL_TOOLS", 2000)
+        self._max_schema_bytes = _env_int("ICA_MCP_PROXY_MAX_SCHEMA_BYTES", 65536)
+        self._pool_stdio = _env_bool("ICA_MCP_PROXY_POOL_STDIO", True)
+        self._disable_pooling = _env_bool("ICA_MCP_PROXY_DISABLE_POOLING", False)
+        self._upstream_idle_ttl_s = _env_float("ICA_MCP_PROXY_UPSTREAM_IDLE_TTL_S", 90)
+        self._upstream_request_timeout_s = _env_float("ICA_MCP_PROXY_UPSTREAM_REQUEST_TIMEOUT_S", 120)
+
+        self._servers_loaded_at: float = 0
+        self._servers: dict[str, dict[str, Any]] = {}
+        self._sources: list[str] = []
+        self._blocked_servers: dict[str, str] = {}
+
+        self._tools_loaded_at: dict[str, float] = {}
+        self._tools_cache: dict[str, list[Any]] = {}
+        self._mirror_map: dict[str, tuple[str, str]] = {}
+        self._last_status: Optional[MirrorStatus] = None
+
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._workers: dict[str, UpstreamWorker] = {}
+        self._workers_lock = asyncio.Lock()
+
+    def _lock_for(self, server: str) -> asyncio.Lock:
+        if server not in self._locks:
+            self._locks[server] = asyncio.Lock()
+        return self._locks[server]
+
+    def _load_servers(self) -> tuple[dict[str, dict[str, Any]], list[str]]:
+        loaded = core["load_servers_merged"](script_file=__file__)
+        servers = dict(loaded.servers)
+        sources = list(loaded.sources)
+        self._blocked_servers = dict(getattr(loaded, "blocked_servers", {}) or {})
+
+        # Reserve "proxy" namespace.
+        if "proxy" in servers:
+            servers.pop("proxy", None)
+        return servers, sources
+
+    async def get_servers(self) -> tuple[dict[str, dict[str, Any]], list[str]]:
+        # Light caching; config reads are cheap but avoid hammering.
+        if time.time() - self._servers_loaded_at > 2:
+            self._servers, self._sources = self._load_servers()
+            self._servers_loaded_at = time.time()
+            await self._prune_workers(valid_servers=set(self._servers.keys()))
+        return self._servers, self._sources
+
+    def _should_pool(self, cfg: dict[str, Any]) -> bool:
+        if self._disable_pooling or not self._pool_stdio:
+            return False
+        try:
+            return core["detect_transport"](cfg) == "stdio"
+        except Exception:
+            return False
+
+    async def _get_worker(self, server_name: str, cfg: dict[str, Any]) -> UpstreamWorker:
+        cfg_fp = _config_fingerprint(cfg)
+        replaced: Optional[UpstreamWorker] = None
+        async with self._workers_lock:
+            existing = self._workers.get(server_name)
+            if existing and existing.config_fingerprint != cfg_fp:
+                replaced = existing
+                self._workers.pop(server_name, None)
+
+            worker = self._workers.get(server_name)
+            if worker is None:
+                worker = UpstreamWorker(
+                    server_name=server_name,
+                    server_cfg=cfg,
+                    idle_ttl_s=self._upstream_idle_ttl_s,
+                    request_timeout_s=self._upstream_request_timeout_s,
+                    script_file=__file__,
+                )
+                self._workers[server_name] = worker
+
+        if replaced is not None:
+            await replaced.shutdown()
+        await worker.ensure_started()
+        return worker
+
+    async def _prune_workers(self, valid_servers: set[str]) -> None:
+        stale: list[UpstreamWorker] = []
+        async with self._workers_lock:
+            for name in list(self._workers.keys()):
+                if name not in valid_servers:
+                    stale.append(self._workers.pop(name))
+        for worker in stale:
+            await worker.shutdown()
+
+    async def invalidate_worker(self, server_name: str) -> None:
+        worker: Optional[UpstreamWorker] = None
+        async with self._workers_lock:
+            worker = self._workers.pop(server_name, None)
+        if worker:
+            await worker.shutdown()
+
+    async def shutdown(self) -> None:
+        async with self._workers_lock:
+            workers = list(self._workers.values())
+            self._workers.clear()
+        for worker in workers:
+            await worker.shutdown()
+
+    async def list_upstream_tools(self, server_name: str) -> list[Any]:
+        servers, _ = await self.get_servers()
+        if server_name not in servers:
+            raise ValueError(f"Unknown upstream server: {server_name}")
+
+        # Cache per server
+        last = self._tools_loaded_at.get(server_name, 0)
+        if time.time() - last < self._tools_cache_ttl_s and server_name in self._tools_cache:
+            return self._tools_cache[server_name]
+
+        async with self._lock_for(server_name):
+            # Re-check inside lock
+            last = self._tools_loaded_at.get(server_name, 0)
+            if time.time() - last < self._tools_cache_ttl_s and server_name in self._tools_cache:
+                return self._tools_cache[server_name]
+
+            cfg = servers[server_name]
+            if self._should_pool(cfg):
+                worker = await self._get_worker(server_name, cfg)
+                res = await worker.list_tools()
+            else:
+                async with core["create_session"](server_name, cfg, script_file=__file__) as session:
+                    res = await session.list_tools()
+            tools = list(res.tools or [])
+            self._tools_cache[server_name] = tools
+            self._tools_loaded_at[server_name] = time.time()
+            return tools
+
+    async def call_upstream(self, server_name: str, tool_name: str, args: dict) -> Any:
+        servers, _ = await self.get_servers()
+        if server_name not in servers:
+            raise ValueError(f"Unknown upstream server: {server_name}")
+
+        cfg = servers[server_name]
+        if self._should_pool(cfg):
+            worker = await self._get_worker(server_name, cfg)
+            return await worker.call_tool(tool_name, args)
+
+        async with self._lock_for(server_name):
+            async with core["create_session"](server_name, cfg, script_file=__file__) as session:
+                return await session.call_tool(tool_name, args)
+
+    async def build_tool_list(self):
+        import mcp.types as types
+
+        servers, sources = await self.get_servers()
+
+        reasons: list[str] = []
+        truncated = False
+
+        broker_tools: list[types.Tool] = _broker_tool_defs()
+
+        server_names = sorted(servers.keys())
+        servers_total = len(server_names)
+        if servers_total > self._max_servers:
+            truncated = True
+            reasons.append(f"Too many servers ({servers_total}) > ICA_MCP_PROXY_MAX_SERVERS ({self._max_servers}).")
+            server_names = server_names[: self._max_servers]
+
+        mirrored: list[types.Tool] = []
+        mirror_map: dict[str, tuple[str, str]] = {}
+
+        total_tools_seen = 0
+        total_tools_mirrored = 0
+
+        for s in server_names:
+            upstream_tools = await self.list_upstream_tools(s)
+            total_tools_seen += len(upstream_tools)
+
+            tools_for_server = list(upstream_tools)[: self._max_tools_per_server]
+            if len(upstream_tools) > self._max_tools_per_server:
+                truncated = True
+                reasons.append(
+                    f"Server '{s}' tools truncated ({len(upstream_tools)}) > ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER ({self._max_tools_per_server})."
+                )
+
+            for t in tools_for_server:
+                if total_tools_mirrored >= self._max_total_tools:
+                    truncated = True
+                    reasons.append(
+                        f"Total tools truncated at ICA_MCP_PROXY_MAX_TOTAL_TOOLS ({self._max_total_tools})."
+                    )
+                    break
+
+                upstream_tool_name = t.name
+                proxy_tool_name = f"{_sanitize(s)}.{_sanitize(upstream_tool_name)}"
+
+                # Ensure tool name is protocol-safe.
+                if not _NAME_OK.match(proxy_tool_name):
+                    proxy_tool_name = _sanitize(proxy_tool_name)
+
+                # Collision handling
+                if proxy_tool_name in mirror_map:
+                    # stable-ish suffix
+                    suffix = hashlib.sha1(f"{s}:{upstream_tool_name}".encode("utf-8")).hexdigest()[:6]
+                    proxy_tool_name = f"{proxy_tool_name}__{suffix}"
+
+                input_schema = getattr(t, "inputSchema", None) or {"type": "object", "additionalProperties": True}
+                output_schema = getattr(t, "outputSchema", None)
+
+                schema_bytes = _schema_size(input_schema)
+                meta = {"ica_proxy": {"upstream_server": s, "upstream_tool": upstream_tool_name}}
+
+                if schema_bytes > self._max_schema_bytes:
+                    truncated = True
+                    reasons.append(
+                        f"Tool schema truncated for '{proxy_tool_name}' ({schema_bytes} bytes) > ICA_MCP_PROXY_MAX_SCHEMA_BYTES ({self._max_schema_bytes})."
+                    )
+                    meta["ica_proxy"]["schema_truncated"] = True
+                    meta["ica_proxy"]["original_schema_bytes"] = schema_bytes
+                    input_schema = {"type": "object", "additionalProperties": True}
+
+                mirrored.append(
+                    types.Tool(
+                        name=proxy_tool_name,
+                        description=(getattr(t, "description", None) or "")[:4000] or None,
+                        inputSchema=input_schema,
+                        outputSchema=output_schema,
+                        _meta=meta,
+                    )
+                )
+                mirror_map[proxy_tool_name] = (s, upstream_tool_name)
+                total_tools_mirrored += 1
+
+            if total_tools_mirrored >= self._max_total_tools:
+                break
+
+        status = MirrorStatus(
+            sources=sources,
+            servers_total=servers_total,
+            servers_mirrored=len(server_names),
+            tools_total=total_tools_seen,
+            tools_mirrored=total_tools_mirrored,
+            truncated=truncated,
+            reasons=reasons,
+            blocked_servers=dict(self._blocked_servers),
+        )
+        self._mirror_map = mirror_map
+        self._last_status = status
+
+        # Always include mirror_status.
+        return broker_tools + mirrored
+
+    def resolve_mirror(self, proxy_tool_name: str) -> Optional[tuple[str, str]]:
+        if proxy_tool_name in self._mirror_map:
+            return self._mirror_map[proxy_tool_name]
+
+        # Fallback parse: "<server>.<tool...>"
+        if "." in proxy_tool_name:
+            server, tool = proxy_tool_name.split(".", 1)
+            return (server, tool)
+        return None
+
+    def mirror_status(self) -> dict:
+        s = self._last_status
+        if not s:
+            return {"status": "unknown", "note": "No mirror status yet. Call list_tools first."}
+        return {
+            "sources": s.sources,
+            "servers_total": s.servers_total,
+            "servers_mirrored": s.servers_mirrored,
+            "tools_total": s.tools_total,
+            "tools_mirrored": s.tools_mirrored,
+            "truncated": s.truncated,
+            "reasons": s.reasons,
+            "blocked_servers": s.blocked_servers,
+        }
+
+
+
+def _broker_tool_defs():
+    import mcp.types as types
+
+    # Minimal schemas for broker tools.
+    obj = {"type": "object", "properties": {}}
+
+    return [
+        types.Tool(
+            name="proxy.list_servers",
+            description="List configured upstream MCP servers (merged from .mcp.json and $ICA_HOME/mcp-servers.json).",
+            inputSchema=obj,
+        ),
+        types.Tool(
+            name="proxy.list_tools",
+            description="List tools from one upstream server. Args: {server, include_schema?}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "include_schema": {"type": "boolean", "default": True},
+                },
+                "required": ["server"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.call",
+            description="Call an upstream tool. Args: {server, tool, args}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "tool": {"type": "string"},
+                    "args": {"type": "object", "additionalProperties": True, "default": {}},
+                },
+                "required": ["server", "tool"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.mirror_status",
+            description="Show mirroring/truncation status and config sources.",
+            inputSchema=obj,
+        ),
+        types.Tool(
+            name="proxy.auth_start",
+            description="Start authentication for an upstream server. Args: {server, flow?}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "flow": {"type": "string"},
+                },
+                "required": ["server"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.auth_status",
+            description="Show cached token status for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+        types.Tool(
+            name="proxy.auth_refresh",
+            description="Force refresh/re-mint credentials for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+        types.Tool(
+            name="proxy.auth_logout",
+            description="Delete cached credentials for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+    ]
+
+
+async def _handle_proxy_tool(rt: ProxyRuntime, tool_name: str, args: dict) -> Any:
+    servers, sources = await rt.get_servers()
+
+    if tool_name == "proxy.list_servers":
+        return {"servers": sorted(servers.keys()), "sources": sources, "blocked_servers": dict(rt._blocked_servers)}
+
+    if tool_name == "proxy.mirror_status":
+        return rt.mirror_status()
+
+    if tool_name == "proxy.list_tools":
+        s = args.get("server")
+        include_schema = bool(args.get("include_schema", True))
+        tools = await rt.list_upstream_tools(str(s))
+        out = []
+        for t in tools:
+            out.append(
+                {
+                    "name": t.name,
+                    "description": getattr(t, "description", None),
+                    "inputSchema": getattr(t, "inputSchema", None) if include_schema else None,
+                    "outputSchema": getattr(t, "outputSchema", None) if include_schema else None,
+                }
+            )
+        return {"server": str(s), "tools": out}
+
+    if tool_name == "proxy.call":
+        s = str(args.get("server"))
+        tn = str(args.get("tool"))
+        call_args = args.get("args") or {}
+        if not isinstance(call_args, dict):
+            raise ValueError("proxy.call args must be an object")
+        return await rt.call_upstream(s, tn, call_args)
+
+    if tool_name in ("proxy.auth_start", "proxy.auth_status", "proxy.auth_refresh", "proxy.auth_logout"):
+        server = str(args.get("server"))
+        if server not in servers:
+            raise ValueError(f"Unknown upstream server: {server}")
+        cfg = servers[server]
+
+        if tool_name == "proxy.auth_status":
+            entry = core["get_token_entry"](server, script_file=__file__)
+            if not entry:
+                return {"server": server, "status": "missing"}
+            return {
+                "server": server,
+                "status": "present",
+                "expires_at": entry.get("expires_at"),
+                "expired": core["token_is_expired"](entry),
+                "scope": entry.get("scope"),
+                "token_type": entry.get("token_type"),
+                "saved_to": str(core["tokens_path"](script_file=__file__) or ""),
+            }
+
+        if tool_name == "proxy.auth_logout":
+            ok = core["delete_token_entry"](server, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return {"server": server, "status": "deleted" if ok else "missing"}
+
+        oauth = core["resolve_oauth_config"](cfg)
+        if not oauth:
+            raise ValueError("Server has no oauth configuration.")
+        flow = (args.get("flow") or oauth.get("type") or "pkce").lower()
+
+        if tool_name == "proxy.auth_refresh":
+            # Force refresh: if client credentials, re-mint; else refresh token path.
+            if flow == "client_credentials":
+                out = await core["oauth_auth_client_credentials"](server, cfg, script_file=__file__)
+                await rt.invalidate_worker(server)
+                return out
+            tok = core["oauth_maybe_refresh"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return {"server": server, "status": "ok" if tok else "missing"}
+
+        # auth_start
+        if flow in ("device_code", "oidc_device_code"):
+            out = await core["oauth_auth_device_code"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return out
+        if flow == "client_credentials":
+            out = await core["oauth_auth_client_credentials"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return out
+        # default pkce
+        out = await core["oauth_auth_pkce"](server, cfg, script_file=__file__)
+        await rt.invalidate_worker(server)
+        return out
+
+    raise ValueError(f"Unknown proxy tool: {tool_name}")
+
+
+async def _run():
+    try:
+        import anyio
+        import mcp.types as types
+        from mcp.server.lowlevel import Server
+        from mcp.server.models import InitializationOptions
+        from mcp.server.stdio import stdio_server
+    except Exception as e:
+        raise RuntimeError(
+            "Missing MCP server dependencies. Install: pip install mcp anyio jsonschema"
+        ) from e
+
+    rt = ProxyRuntime()
+
+    server = Server("ica-mcp-proxy")
+
+    @server.list_tools()
+    async def _list_tools():
+        return await rt.build_tool_list()
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict):
+        if name.startswith("proxy."):
+            res = await _handle_proxy_tool(rt, name, arguments or {})
+            return res
+
+        resolved = rt.resolve_mirror(name)
+        if not resolved:
+            raise ValueError(f"Unknown tool: {name}")
+        upstream_server, upstream_tool = resolved
+        # If upstream_server was sanitized in tool name, try best-effort match.
+        # Prefer exact match; else match by sanitized name.
+        servers, _ = await rt.get_servers()
+        if upstream_server not in servers:
+            candidates = {_sanitize(k): k for k in servers.keys()}
+            if upstream_server in candidates:
+                upstream_server = candidates[upstream_server]
+        return await rt.call_upstream(upstream_server, upstream_tool, arguments or {})
+
+    capabilities = types.ServerCapabilities(tools=types.ToolsCapability(listChanged=False))
+    init = InitializationOptions(
+        server_name="ica-mcp-proxy",
+        server_version=os.environ.get("ICA_VERSION", "dev"),
+        capabilities=capabilities,
+        instructions="ICA MCP proxy: use proxy.* broker tools or call mirrored tools as <server>.<tool>.",
+    )
+
+    try:
+        async with stdio_server() as (read, write):
+            await server.run(read, write, init)
+    finally:
+        await rt.shutdown()
+
+
+def main():
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mcp_proxy/test_proxy.py
+++ b/tests/mcp_proxy/test_proxy.py
@@ -1,0 +1,323 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+
+def _have_mcp():
+    try:
+        import mcp  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_have_mcp(), "python package 'mcp' not installed")
+class TestMcpProxy(unittest.TestCase):
+    def test_config_merge_precedence(self):
+        # Load core from repo path.
+        repo = Path(__file__).resolve().parents[2]
+        core_dir = repo / "src" / "skills" / "mcp-common" / "scripts"
+        sys.path.insert(0, str(core_dir))
+        import ica_mcp_core  # type: ignore
+
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            proj = td / "project"
+            proj.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+
+            (proj / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "a": {"command": "python", "args": ["-c", "print('a')"]},
+                            "shared": {"command": "python", "args": ["-c", "print('project')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # ICA home file
+            (ica_home / "mcp-servers.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "b": {"command": "python", "args": ["-c", "print('b')"]},
+                            "shared": {"command": "python", "args": ["-c", "print('home')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            # Pretend this is an installed ICA home.
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            old_ica_home = os.environ.get("ICA_HOME")
+            os.environ["ICA_HOME"] = str(ica_home)
+            try:
+                loaded = ica_mcp_core.load_servers_merged(script_file=None, cwd=proj)  # type: ignore[arg-type]
+            finally:
+                if old_ica_home is None:
+                    del os.environ["ICA_HOME"]
+                else:
+                    os.environ["ICA_HOME"] = old_ica_home
+            self.assertIn("a", loaded.servers)
+            self.assertIn("b", loaded.servers)
+            # Default precedence: project overrides home.
+            self.assertEqual(loaded.servers["shared"]["args"][-1], "print('project')")
+
+            old_ica_home = os.environ.get("ICA_HOME")
+            os.environ["ICA_HOME"] = str(ica_home)
+            # The loader reads process env; set it for this call.
+            old = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME")
+            os.environ["ICA_MCP_CONFIG_PREFER_HOME"] = "1"
+            try:
+                loaded2 = ica_mcp_core.load_servers_merged(script_file=None, cwd=proj)  # type: ignore[arg-type]
+                self.assertEqual(loaded2.servers["shared"]["args"][-1], "print('home')")
+            finally:
+                if old is None:
+                    del os.environ["ICA_MCP_CONFIG_PREFER_HOME"]
+                else:
+                    os.environ["ICA_MCP_CONFIG_PREFER_HOME"] = old
+                if old_ica_home is None:
+                    del os.environ["ICA_HOME"]
+                else:
+                    os.environ["ICA_HOME"] = old_ica_home
+
+    def test_proxy_mirrors_and_calls(self):
+        import anyio
+        from mcp import StdioServerParameters
+        from mcp.client.stdio import stdio_client
+        from mcp import ClientSession
+
+        repo = Path(__file__).resolve().parents[2]
+        proxy_script = repo / "src" / "skills" / "mcp-proxy" / "scripts" / "mcp_proxy_server.py"
+
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            project = td / "project"
+            project.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            # Upstream FastMCP stdio server script
+            upstream = td / "upstream.py"
+            upstream.write_text(
+                textwrap.dedent(
+                    """
+                    from mcp.server.fastmcp import FastMCP
+                    import os
+
+                    mcp = FastMCP("fixture")
+
+                    @mcp.tool()
+                    def echo(text: str) -> str:
+                        return text
+
+                    @mcp.tool()
+                    def add(a: int, b: int) -> int:
+                        return a + b
+
+                    @mcp.tool()
+                    def pid() -> int:
+                        return os.getpid()
+
+                    if __name__ == "__main__":
+                        mcp.run()
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            (project / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "fixture": {
+                                "command": sys.executable,
+                                "args": [str(upstream)],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            # Run proxy as stdio server via the MCP client.
+            env = dict(os.environ)
+            env["ICA_HOME"] = str(ica_home)
+
+            params = StdioServerParameters(
+                command=sys.executable,
+                args=[str(proxy_script)],
+                env=env,
+                cwd=str(project),
+            )
+
+            async def run():
+                async with stdio_client(params) as (read, write):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+
+                        tools = await session.list_tools()
+                        names = {t.name for t in tools.tools}
+                        self.assertIn("proxy.list_servers", names)
+                        # Mirrored tool names
+                        self.assertIn("fixture.echo", names)
+                        self.assertIn("fixture.add", names)
+                        self.assertIn("fixture.pid", names)
+
+                        # Call mirrored
+                        res = await session.call_tool("fixture.echo", {"text": "hi"})
+                        # Content is text in most cases.
+                        text = None
+                        for item in res.content:
+                            if hasattr(item, "text"):
+                                text = item.text
+                                break
+                        self.assertEqual(text, "hi")
+
+                        # Call via broker
+                        res2 = await session.call_tool(
+                            "proxy.call",
+                            {"server": "fixture", "tool": "add", "args": {"a": 2, "b": 3}},
+                        )
+                        text2 = None
+                        for item in res2.content:
+                            if hasattr(item, "text"):
+                                text2 = item.text
+                                break
+                        # FastMCP returns "5" as text.
+                        self.assertIn("5", str(text2))
+
+                        # Stdio pooling keeps a stable upstream process/session for repeated calls.
+                        p1 = await session.call_tool("fixture.pid", {})
+                        p2 = await session.call_tool("fixture.pid", {})
+                        pid1 = next((item.text for item in p1.content if hasattr(item, "text")), None)
+                        pid2 = next((item.text for item in p2.content if hasattr(item, "text")), None)
+                        self.assertEqual(pid1, pid2)
+
+            anyio.run(run)
+
+    def test_proxy_concurrent_burst_on_pooled_stdio(self):
+        import anyio
+        from mcp import ClientSession
+        from mcp import StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        repo = Path(__file__).resolve().parents[2]
+        proxy_script = repo / "src" / "skills" / "mcp-proxy" / "scripts" / "mcp_proxy_server.py"
+
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            project = td / "project"
+            project.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            upstream = td / "upstream.py"
+            upstream.write_text(
+                textwrap.dedent(
+                    """
+                    from mcp.server.fastmcp import FastMCP
+                    import os
+                    import time
+
+                    mcp = FastMCP("fixture")
+
+                    @mcp.tool()
+                    def pid() -> int:
+                        return os.getpid()
+
+                    @mcp.tool()
+                    def sleepy_pid(delay_ms: int = 5) -> int:
+                        time.sleep(max(0, delay_ms) / 1000)
+                        return os.getpid()
+
+                    if __name__ == "__main__":
+                        mcp.run()
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            (project / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "fixture": {
+                                "command": sys.executable,
+                                "args": [str(upstream)],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            env = dict(os.environ)
+            env["ICA_HOME"] = str(ica_home)
+            env["ICA_MCP_PROXY_POOL_STDIO"] = "1"
+            env["ICA_MCP_PROXY_DISABLE_POOLING"] = "0"
+            env["ICA_MCP_PROXY_UPSTREAM_IDLE_TTL_S"] = "120"
+            env["ICA_MCP_PROXY_UPSTREAM_REQUEST_TIMEOUT_S"] = "30"
+
+            params = StdioServerParameters(
+                command=sys.executable,
+                args=[str(proxy_script)],
+                env=env,
+                cwd=str(project),
+            )
+
+            async def run():
+                import asyncio
+
+                async with stdio_client(params) as (read, write):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        await session.list_tools()
+
+                        async def one_call(i: int) -> str:
+                            # Mix mirrored and broker calls in one burst.
+                            if i % 2 == 0:
+                                res = await session.call_tool("fixture.sleepy_pid", {"delay_ms": 8})
+                            else:
+                                res = await session.call_tool(
+                                    "proxy.call",
+                                    {"server": "fixture", "tool": "sleepy_pid", "args": {"delay_ms": 8}},
+                                )
+                            text = next((item.text for item in res.content if hasattr(item, "text")), None)
+                            self.assertIsNotNone(text)
+                            return str(text)
+
+                        pids = await asyncio.gather(*[one_call(i) for i in range(40)])
+                        self.assertEqual(len(pids), 40)
+                        self.assertEqual(len(set(pids)), 1)
+
+                        # Follow-up calls should stay healthy after the burst.
+                        follow_up = await session.call_tool("fixture.pid", {})
+                        follow_up_pid = next(
+                            (item.text for item in follow_up.content if hasattr(item, "text")),
+                            None,
+                        )
+                        self.assertIsNotNone(follow_up_pid)
+                        self.assertEqual(str(follow_up_pid), pids[0])
+
+            anyio.run(run)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mcp_proxy/test_security_core.py
+++ b/tests/mcp_proxy/test_security_core.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+
+def _load_core():
+    repo = Path(__file__).resolve().parents[2]
+    core_dir = repo / "src" / "skills" / "mcp-common" / "scripts"
+    sys.path.insert(0, str(core_dir))
+    import ica_mcp_core  # type: ignore
+
+    return ica_mcp_core
+
+
+class TestMcpCoreSecurity(unittest.TestCase):
+    def test_validate_secure_url_blocks_plain_http_non_loopback(self):
+        core = _load_core()
+        with self.assertRaises(ValueError):
+            core._validate_secure_url("http://example.com/token", field="oauth.token_url", allow_http_loopback=True)
+
+    def test_validate_secure_url_allows_loopback_http_for_dev(self):
+        core = _load_core()
+        core._validate_secure_url("http://127.0.0.1:8080/token", field="oauth.token_url", allow_http_loopback=True)
+
+    def test_pkce_rejects_non_loopback_redirect_host(self):
+        core = _load_core()
+        cfg = {
+            "oauth": {
+                "type": "pkce",
+                "authorization_url": "https://auth.example.com/authorize",
+                "token_url": "https://auth.example.com/token",
+                "client_id": "abc123",
+                "redirect_uri": "http://0.0.0.0:8765/callback",
+                "scopes": ["openid"],
+            }
+        }
+        with self.assertRaises(ValueError):
+            asyncio.run(core.oauth_auth_pkce("test-server", cfg, script_file=None))
+
+    def test_client_credentials_rejects_http_token_endpoint(self):
+        core = _load_core()
+        cfg = {
+            "oauth": {
+                "type": "client_credentials",
+                "token_url": "http://example.com/oauth/token",
+                "client_id": "cid",
+                "client_secret": "secret",
+            }
+        }
+        with self.assertRaises(ValueError):
+            asyncio.run(core.oauth_auth_client_credentials("test-server", cfg, script_file=None))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/mcp_proxy/test_trust_gate.py
+++ b/tests/mcp_proxy/test_trust_gate.py
@@ -1,0 +1,163 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_core():
+    repo = Path(__file__).resolve().parents[2]
+    core_dir = repo / "src" / "skills" / "mcp-common" / "scripts"
+    sys.path.insert(0, str(core_dir))
+    import ica_mcp_core  # type: ignore
+
+    return ica_mcp_core
+
+
+class _EnvGuard:
+    def __init__(self, updates: dict[str, str | None]):
+        self._updates = updates
+        self._old: dict[str, str | None] = {}
+
+    def __enter__(self):
+        for k, v in self._updates.items():
+            self._old[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def __exit__(self, exc_type, exc, tb):
+        for k, old in self._old.items():
+            if old is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = old
+
+
+class TestTrustGate(unittest.TestCase):
+    def test_strict_blocks_project_stdio_until_trusted(self):
+        core = _load_core()
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            project = td / "project"
+            project.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            (project / ".mcp.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "project-stdio": {"command": "python3", "args": ["-c", "print('ok')"]},
+                            "project-http": {"url": "https://example.com/mcp"},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (ica_home / "mcp-servers.json").write_text(
+                json.dumps({"mcpServers": {"home-stdio": {"command": "python3", "args": ["-c", "print('ok')"]}}}),
+                encoding="utf-8",
+            )
+
+            with _EnvGuard(
+                {
+                    "ICA_HOME": str(ica_home),
+                    "ICA_MCP_STRICT_TRUST": "1",
+                    "ICA_MCP_ALLOW_PROJECT_STDIO": None,
+                    "MCP_CONFIG": None,
+                    "MCP_CONFIG_PATH": None,
+                }
+            ):
+                loaded = core.load_servers_merged(script_file=None, cwd=project)
+                self.assertNotIn("project-stdio", loaded.servers)
+                self.assertIn("project-http", loaded.servers)
+                self.assertIn("home-stdio", loaded.servers)
+                self.assertIn("project-stdio", loaded.blocked_servers)
+
+                trust = core.trust_project(project, script_file=None)
+                self.assertTrue(trust["trusted"])
+
+                loaded2 = core.load_servers_merged(script_file=None, cwd=project)
+                self.assertIn("project-stdio", loaded2.servers)
+                self.assertEqual(loaded2.blocked_servers, {})
+
+    def test_strict_allows_temporary_env_override(self):
+        core = _load_core()
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            project = td / "project"
+            project.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            (project / ".mcp.json").write_text(
+                json.dumps({"mcpServers": {"project-stdio": {"command": "python3", "args": ["-c", "print('ok')"]}}}),
+                encoding="utf-8",
+            )
+
+            with _EnvGuard(
+                {
+                    "ICA_HOME": str(ica_home),
+                    "ICA_MCP_STRICT_TRUST": "1",
+                    "ICA_MCP_ALLOW_PROJECT_STDIO": "1",
+                    "MCP_CONFIG": None,
+                    "MCP_CONFIG_PATH": None,
+                }
+            ):
+                loaded = core.load_servers_merged(script_file=None, cwd=project)
+                self.assertIn("project-stdio", loaded.servers)
+                self.assertEqual(loaded.blocked_servers, {})
+
+    def test_strict_requires_retrust_after_project_config_change(self):
+        core = _load_core()
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            project = td / "project"
+            project.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            mcp_path = project / ".mcp.json"
+            mcp_path.write_text(
+                json.dumps({"mcpServers": {"project-stdio": {"command": "python3", "args": ["-c", "print('ok')"]}}}),
+                encoding="utf-8",
+            )
+
+            with _EnvGuard(
+                {
+                    "ICA_HOME": str(ica_home),
+                    "ICA_MCP_STRICT_TRUST": "1",
+                    "ICA_MCP_ALLOW_PROJECT_STDIO": None,
+                    "MCP_CONFIG": None,
+                    "MCP_CONFIG_PATH": None,
+                }
+            ):
+                core.trust_project(project, script_file=None)
+                loaded = core.load_servers_merged(script_file=None, cwd=project)
+                self.assertIn("project-stdio", loaded.servers)
+
+                # Modify config; trust hash should invalidate.
+                mcp_path.write_text(
+                    json.dumps(
+                        {
+                            "mcpServers": {
+                                "project-stdio": {"command": "python3", "args": ["-c", "print('changed')"]}
+                            }
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                loaded2 = core.load_servers_merged(script_file=None, cwd=project)
+                self.assertNotIn("project-stdio", loaded2.servers)
+                self.assertIn("project-stdio", loaded2.blocked_servers)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -20,6 +20,15 @@ else
   echo "No unit tests found yet"
 fi
 
+# Run Python MCP proxy tests if present (best-effort).
+if command -v python3 >/dev/null 2>&1 && [ -d "tests/mcp_proxy" ]; then
+  echo "🐍 Python tests..."
+  # Don't fail the whole suite if dependencies aren't installed; unittest will skip when mcp is missing.
+  python3 -m unittest discover -s tests/mcp_proxy -p "test_*.py"
+else
+  echo "No Python tests found (or python3 missing)"
+fi
+
 # Run integration tests (once they exist)
 if [ -d "tests/hooks/integration" ] && [ "$(ls -A tests/hooks/integration/*.js 2>/dev/null)" ]; then
   echo "🔗 Integration tests..."


### PR DESCRIPTION
## Summary
- add ICA-owned `mcp-proxy` skill and stdio proxy server for register-once MCP integration across agent runtimes
- add shared `mcp-common` core for config layering, OAuth flows, token storage, trust gating, and transport session creation
- add stdio upstream pooling via dedicated per-server worker tasks to avoid AnyIO cancel-scope shutdown issues
- add optional strict project trust gate for project-defined stdio servers with simple CLI greenlight/untrust commands
- add docs for generic multi-agent setup + auth flows + trust management and update docs index
- add MCP proxy/core test suites and hook test runner integration

## Validation
- `./tests/run-tests.sh`
- `python3 -m unittest discover -s tests/mcp_proxy -p 'test_*.py'`

## Notes
- local memory export files were intentionally not committed
