### PR TITLE
feat: add generalized tdd skill

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Skills are the primary interface for specialized capabilities. They are:
 **Categories:**
 - **Role Skills (14):** pm, architect, developer, system-engineer, devops-engineer, database-engineer, security-engineer, ai-engineer, web-designer, qa-engineer, backend-tester, requirements-engineer, user-tester, reviewer
 - **Command Skills (2):** ica-version, ica-get-setting
-- **Process Skills:** thinking, work-queue, process, best-practices, validate, autonomy, parallel-execution, workflow, mcp-config, story-breakdown, git-privacy, commit-pr, pr-automerge, release, suggest
+- **Process Skills:** thinking, work-queue, process, best-practices, validate, autonomy, parallel-execution, workflow, mcp-config, story-breakdown, git-privacy, commit-pr, pr-automerge, release, suggest, tdd
 - **Enforcement Companion Skills (3):** file-placement, branch-protection, infrastructure-protection
 - **Meta Skills (2):** skill-creator, skill-writer
 

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -44,10 +44,10 @@ qa-engineer, backend-tester, requirements-engineer, user-tester, reviewer
 ### Tooling Skills (1)
 - `agent-browser`: reproduce/debug web UI flows via Agent Browser CLI (snapshots, screenshots, redirects, console/network/errors)
 
-### Process Skills (15)
+### Process Skills (17)
 thinking, work-queue, process, best-practices, validate,
 autonomy, parallel-execution, workflow, mcp-config,
-story-breakdown, git-privacy, commit-pr, release, suggest, memory
+story-breakdown, git-privacy, commit-pr, pr-automerge, release, suggest, memory, tdd
 
 ### Enforcement Companion Skills (3)
 file-placement, branch-protection, infrastructure-protection

--- a/src/catalog/skills.catalog.json
+++ b/src/catalog/skills.catalog.json
@@ -560,6 +560,21 @@
       "sourcePath": "src/skills/system-engineer"
     },
     {
+      "name": "tdd",
+      "description": "Activate when user asks for Test-Driven Development, test-first implementation, red-green-refactor, or writing tests before code. Use for feature work, bug fixes, and refactors where behavior can be specified and verified incrementally with automated tests.",
+      "category": "process",
+      "dependencies": [],
+      "compatibleTargets": [
+        "claude",
+        "codex",
+        "cursor",
+        "gemini",
+        "antigravity"
+      ],
+      "resources": [],
+      "sourcePath": "src/skills/tdd"
+    },
+    {
       "name": "thinking",
       "description": "Activate when facing complex problems, multi-step decisions, high-risk changes, complex debugging, or architectural decisions. Activate when careful analysis is needed before taking action. Provides explicit step-by-step validation.",
       "category": "process",

--- a/src/skills/tdd/SKILL.md
+++ b/src/skills/tdd/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: tdd
+description: Activate when user asks for Test-Driven Development, test-first implementation, red-green-refactor, or writing tests before code. Use for feature work, bug fixes, and refactors where behavior can be specified and verified incrementally with automated tests.
+---
+
+# TDD Skill
+
+General-purpose Test-Driven Development workflow for product code.
+
+## When to Use
+
+- User asks for TDD, test-first, or red-green-refactor
+- Implementing a new feature with clear behavior
+- Fixing a bug and preventing regression
+- Refactoring code while preserving behavior
+- Working in unfamiliar code where tests reduce risk
+
+## When Not to Use
+
+- One-off prototypes where tests are explicitly out of scope
+- Tasks with no practical automated verification path
+- Purely cosmetic edits where behavior does not change
+
+## Core Loop: Red -> Green -> Refactor
+
+1. **Define a single behavior slice**
+   - Capture one user-visible outcome at a time.
+   - Prefer smallest meaningful increment.
+
+2. **Write a failing test first (`RED`)**
+   - Add or update one focused test.
+   - Run the narrowest command that executes the test.
+   - Confirm it fails for the expected reason.
+
+3. **Implement the minimum code to pass (`GREEN`)**
+   - Change only what is needed to satisfy the test.
+   - Avoid speculative abstractions.
+   - Re-run the focused test, then nearby tests.
+
+4. **Improve design without changing behavior (`REFACTOR`)**
+   - Remove duplication and improve naming/structure.
+   - Keep tests green after each small refactor step.
+
+5. **Repeat**
+   - Add the next failing test for the next behavior slice.
+   - Continue until acceptance criteria are covered.
+
+## Test Planning Pattern
+
+Before coding, define lightweight acceptance checks:
+
+| Test ID | Type | Scenario | Expected Result |
+| --- | --- | --- | --- |
+| T1 | Happy path | valid input | expected output returned |
+| T2 | Edge case | boundary input | stable, correct behavior |
+| T3 | Error path | invalid input | safe, explicit failure |
+| T4 | Regression | previously broken flow | bug stays fixed |
+
+## Practical Rules
+
+- Start with behavior, not internal implementation details.
+- Use deterministic tests (no flaky timing/network dependencies).
+- Keep tests readable (Arrange -> Act -> Assert).
+- For bug fixes, write the regression test before the code fix.
+- For legacy code, write characterization tests first, then refactor.
+- Run full relevant test suite before finishing.
+
+## Validation Checklist
+
+- [ ] Tests were written/updated before implementation changes
+- [ ] First test run failed for expected reason
+- [ ] Minimal implementation made tests pass
+- [ ] Refactor preserved green test state
+- [ ] New behavior and regression paths are covered
+- [ ] Relevant suite passes end-to-end
+
+## Output Contract
+
+When this skill is used, produce:
+
+1. Test plan (happy path, edge, error, regression)
+2. Evidence of initial failing test(s)
+3. Code change summary tied to passing tests
+4. Final test results and residual risks (if any)


### PR DESCRIPTION
## Summary
- add a new portable `tdd` skill for test-first development across supported agent targets
- define explicit red/green/refactor workflow, test planning pattern, validation checklist, and output contract
- update architecture and skills-reference docs to include `tdd` in process skills

## Changes
- added `src/skills/tdd/SKILL.md`
- updated `docs/skills-reference.md` process skill list/count and included `pr-automerge` for consistency
- updated `docs/architecture.md` process skill list
- refreshed `src/catalog/skills.catalog.json` to include the new skill

## Test Plan
- [x] `make test`
- [x] Verify installer output includes `tdd` for `claude` and `codex` targets
- [x] Manual diff review for docs/catalog consistency

## Breaking Changes
- none