### PR TITLE
feat: add tracking config bootstrap and TDD defaults

### DIFF
--- a/src/installer-core/trackingConfig.ts
+++ b/src/installer-core/trackingConfig.ts
@@ -1,0 +1,303 @@
+import path from "node:path";
+
+export type TrackingProvider = "github" | "file-based" | "linear" | "jira";
+
+export interface TrackingConfig {
+  issue_tracking?: {
+    enabled?: boolean;
+    provider?: TrackingProvider | string;
+  };
+  tdd?: {
+    enabled?: boolean;
+  };
+  [key: string]: unknown;
+}
+
+export interface TrackingConfigDependencies {
+  cwd: string;
+  icaHome?: string;
+  homeDir: string;
+  pathExists: (targetPath: string) => Promise<boolean>;
+  readText: (targetPath: string) => Promise<string>;
+}
+
+export interface EnsureTrackingConfigDependencies extends TrackingConfigDependencies {
+  writeText: (targetPath: string, content: string) => Promise<void>;
+}
+
+export interface ResolveTrackingConfigOptions {
+  detectGithub?: () => boolean | Promise<boolean>;
+}
+
+export interface EnsureTrackingConfigOptions extends ResolveTrackingConfigOptions {
+  prompts?: {
+    selectScope?: (context: { projectConfigPath: string; existingSystemConfigPath: string | null }) => Promise<"project" | "system">;
+    selectProvider?: (context: { defaultProvider: TrackingProvider; targetScope: "project" | "system" }) => Promise<TrackingProvider>;
+  };
+}
+
+export interface EnsureTddPreferenceOptions {
+  resolution: TrackingConfigResolution;
+  tddSkillActive: boolean;
+  prompts?: {
+    selectDefaultEnabled?: (context: { path: string | null; currentDefault: boolean | null }) => Promise<boolean>;
+    selectApplyForScope?: (context: { defaultEnabled: boolean }) => Promise<boolean>;
+  };
+}
+
+export interface TddPreferenceResolution {
+  defaultEnabled: boolean;
+  applyForScope: boolean;
+  persistedDefault: boolean;
+}
+
+export interface TrackingConfigResolution {
+  source: "project" | "system" | "agent-home" | "none";
+  path: string | null;
+  config: TrackingConfig | null;
+  missingConfig: boolean;
+  fallbackProvider: TrackingProvider;
+  diagnostics: string[];
+}
+
+function normalizeProvider(value: unknown): TrackingProvider | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "github") return "github";
+  if (normalized === "file-based") return "file-based";
+  if (normalized === "linear") return "linear";
+  if (normalized === "jira") return "jira";
+  return null;
+}
+
+function getDefaultFallbackProvider(githubAvailable: boolean): TrackingProvider {
+  return githubAvailable ? "github" : "file-based";
+}
+
+function candidatePaths(deps: TrackingConfigDependencies): Array<{ path: string; source: "project" | "system" | "agent-home" }> {
+  const candidates: Array<{ path: string; source: "project" | "system" | "agent-home" }> = [];
+  candidates.push({
+    path: path.resolve(deps.cwd, ".agent", "tracking.config.json"),
+    source: "project",
+  });
+
+  if (deps.icaHome && deps.icaHome.trim().length > 0) {
+    candidates.push({
+      path: path.resolve(deps.icaHome, "tracking.config.json"),
+      source: "system",
+    });
+  }
+
+  candidates.push({
+    path: path.resolve(deps.homeDir, ".codex", "tracking.config.json"),
+    source: "agent-home",
+  });
+  candidates.push({
+    path: path.resolve(deps.homeDir, ".claude", "tracking.config.json"),
+    source: "agent-home",
+  });
+  return candidates;
+}
+
+function defaultSystemConfigPath(deps: TrackingConfigDependencies): string {
+  if (deps.icaHome && deps.icaHome.trim().length > 0) {
+    return path.resolve(deps.icaHome, "tracking.config.json");
+  }
+  return path.resolve(deps.homeDir, ".codex", "tracking.config.json");
+}
+
+async function detectGithubDefault(options?: ResolveTrackingConfigOptions): Promise<boolean> {
+  if (!options?.detectGithub) return false;
+  return Boolean(await options.detectGithub());
+}
+
+function createDefaultTrackingConfig(provider: TrackingProvider): TrackingConfig {
+  return {
+    issue_tracking: {
+      enabled: true,
+      provider,
+    },
+    tdd: {
+      enabled: false,
+    },
+  };
+}
+
+export async function resolveTrackingConfig(
+  deps: TrackingConfigDependencies,
+  options?: ResolveTrackingConfigOptions,
+): Promise<TrackingConfigResolution> {
+  const diagnostics: string[] = [];
+  const candidates = candidatePaths(deps);
+  for (const candidate of candidates) {
+    if (!(await deps.pathExists(candidate.path))) continue;
+
+    let parsed: TrackingConfig | null = null;
+    try {
+      const raw = await deps.readText(candidate.path);
+      parsed = raw.trim().length > 0 ? (JSON.parse(raw) as TrackingConfig) : {};
+    } catch {
+      diagnostics.push(`Invalid JSON at ${candidate.path}`);
+      parsed = null;
+    }
+
+    const issueTrackingEnabled = parsed?.issue_tracking?.enabled !== false;
+    const configProvider = normalizeProvider(parsed?.issue_tracking?.provider);
+    const fallbackProvider =
+      !issueTrackingEnabled
+        ? "file-based"
+        : configProvider || getDefaultFallbackProvider(await detectGithubDefault(options));
+
+    return {
+      source: candidate.source,
+      path: candidate.path,
+      config: parsed,
+      missingConfig: false,
+      fallbackProvider,
+      diagnostics,
+    };
+  }
+
+  return {
+    source: "none",
+    path: null,
+    config: null,
+    missingConfig: true,
+    fallbackProvider: getDefaultFallbackProvider(await detectGithubDefault(options)),
+    diagnostics,
+  };
+}
+
+export async function ensureTrackingConfig(
+  deps: EnsureTrackingConfigDependencies,
+  options?: EnsureTrackingConfigOptions,
+): Promise<TrackingConfigResolution> {
+  const projectConfigPath = path.resolve(deps.cwd, ".agent", "tracking.config.json");
+  const resolution = await resolveTrackingConfig(deps, options);
+  if (resolution.source === "project") {
+    return resolution;
+  }
+
+  const projectExists = await deps.pathExists(projectConfigPath);
+  if (projectExists) {
+    return resolution;
+  }
+
+  if (resolution.source !== "none") {
+    const selectedScope = options?.prompts?.selectScope
+      ? await options.prompts.selectScope({
+          projectConfigPath,
+          existingSystemConfigPath: resolution.path,
+        })
+      : "system";
+    if (selectedScope === "system") {
+      return resolution;
+    }
+
+    const targetProvider = options?.prompts?.selectProvider
+      ? await options.prompts.selectProvider({
+          defaultProvider: resolution.fallbackProvider,
+          targetScope: "project",
+        })
+      : resolution.fallbackProvider;
+    const nextConfig = createDefaultTrackingConfig(targetProvider);
+    await deps.writeText(projectConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
+    return {
+      source: "project",
+      path: projectConfigPath,
+      config: nextConfig,
+      missingConfig: false,
+      fallbackProvider: targetProvider,
+      diagnostics: [...resolution.diagnostics, "Created project tracking config"],
+    };
+  }
+
+  const systemConfigPath = defaultSystemConfigPath(deps);
+  const targetProvider = options?.prompts?.selectProvider
+    ? await options.prompts.selectProvider({
+        defaultProvider: resolution.fallbackProvider,
+        targetScope: "system",
+      })
+    : resolution.fallbackProvider;
+  const nextConfig = createDefaultTrackingConfig(targetProvider);
+  await deps.writeText(systemConfigPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
+  return {
+    source: "system",
+    path: systemConfigPath,
+    config: nextConfig,
+    missingConfig: false,
+    fallbackProvider: targetProvider,
+    diagnostics: [...resolution.diagnostics, "Created system tracking config"],
+  };
+}
+
+export async function ensureTddPreference(
+  deps: EnsureTrackingConfigDependencies,
+  options: EnsureTddPreferenceOptions,
+): Promise<TddPreferenceResolution> {
+  const resolution = options.resolution;
+  const currentDefault = typeof resolution.config?.tdd?.enabled === "boolean" ? resolution.config.tdd.enabled : null;
+  let defaultEnabled = currentDefault ?? false;
+  let persistedDefault = false;
+
+  if (options.tddSkillActive && currentDefault === null) {
+    defaultEnabled = options.prompts?.selectDefaultEnabled
+      ? await options.prompts.selectDefaultEnabled({
+          path: resolution.path,
+          currentDefault,
+        })
+      : false;
+
+    if (resolution.path) {
+      const nextConfig: TrackingConfig = {
+        ...(resolution.config || {}),
+        tdd: {
+          enabled: defaultEnabled,
+        },
+      };
+      await deps.writeText(resolution.path, `${JSON.stringify(nextConfig, null, 2)}\n`);
+      resolution.config = nextConfig;
+      persistedDefault = true;
+    }
+  }
+
+  const applyForScope = options.tddSkillActive
+    ? options.prompts?.selectApplyForScope
+      ? await options.prompts.selectApplyForScope({ defaultEnabled })
+      : defaultEnabled
+    : false;
+
+  return {
+    defaultEnabled,
+    applyForScope,
+    persistedDefault,
+  };
+}
+
+export async function updateTrackingProvider(
+  deps: EnsureTrackingConfigDependencies,
+  configPath: string,
+  provider: TrackingProvider,
+): Promise<TrackingConfig> {
+  let current: TrackingConfig = {};
+  try {
+    const raw = await deps.readText(configPath);
+    current = raw.trim().length > 0 ? (JSON.parse(raw) as TrackingConfig) : {};
+  } catch {
+    current = {};
+  }
+
+  const next: TrackingConfig = {
+    ...current,
+    issue_tracking: {
+      enabled: true,
+      ...(current.issue_tracking || {}),
+      provider,
+    },
+    tdd: {
+      enabled: current.tdd?.enabled ?? false,
+    },
+  };
+  await deps.writeText(configPath, `${JSON.stringify(next, null, 2)}\n`);
+  return next;
+}

--- a/tests/installer/tracking-config.test.ts
+++ b/tests/installer/tracking-config.test.ts
@@ -1,0 +1,312 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import {
+  ensureTrackingConfig,
+  ensureTddPreference,
+  resolveTrackingConfig,
+  updateTrackingProvider,
+  type EnsureTrackingConfigDependencies,
+  type TrackingConfigDependencies,
+  type TrackingProvider,
+} from "../../src/installer-core/trackingConfig";
+
+function createDeps(existingPaths: string[]): TrackingConfigDependencies {
+  const normalized = new Set(existingPaths.map((entry) => path.resolve(entry)));
+  return {
+    cwd: path.resolve("/workspace/project"),
+    icaHome: path.resolve("/workspace/home/.ica"),
+    homeDir: path.resolve("/workspace/home"),
+    pathExists: async (targetPath: string) => normalized.has(path.resolve(targetPath)),
+    readText: async () => "",
+  };
+}
+
+function createDepsWithContents(contents: Record<string, string>): TrackingConfigDependencies {
+  const normalizedContents = new Map<string, string>();
+  for (const [targetPath, content] of Object.entries(contents)) {
+    normalizedContents.set(path.resolve(targetPath), content);
+  }
+
+  return {
+    cwd: path.resolve("/workspace/project"),
+    icaHome: path.resolve("/workspace/home/.ica"),
+    homeDir: path.resolve("/workspace/home"),
+    pathExists: async (targetPath: string) => normalizedContents.has(path.resolve(targetPath)),
+    readText: async (targetPath: string) => normalizedContents.get(path.resolve(targetPath)) || "",
+  };
+}
+
+function createEnsureDeps(
+  contents: Record<string, string>,
+): {
+  deps: EnsureTrackingConfigDependencies;
+  writes: Array<{ targetPath: string; content: string }>;
+} {
+  const normalizedContents = new Map<string, string>();
+  for (const [targetPath, content] of Object.entries(contents)) {
+    normalizedContents.set(path.resolve(targetPath), content);
+  }
+
+  const writes: Array<{ targetPath: string; content: string }> = [];
+  const deps: EnsureTrackingConfigDependencies = {
+    cwd: path.resolve("/workspace/project"),
+    icaHome: path.resolve("/workspace/home/.ica"),
+    homeDir: path.resolve("/workspace/home"),
+    pathExists: async (targetPath: string) => normalizedContents.has(path.resolve(targetPath)),
+    readText: async (targetPath: string) => normalizedContents.get(path.resolve(targetPath)) || "",
+    writeText: async (targetPath: string, content: string) => {
+      writes.push({ targetPath: path.resolve(targetPath), content });
+      normalizedContents.set(path.resolve(targetPath), content);
+    },
+  };
+  return { deps, writes };
+}
+
+test("resolveTrackingConfig prefers project config over all fallbacks", async () => {
+  const projectConfig = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const systemConfig = path.join("/workspace/home/.ica", "tracking.config.json");
+
+  const deps = createDeps([projectConfig, systemConfig]);
+  const result = await resolveTrackingConfig(deps);
+
+  assert.equal(result.source, "project");
+  assert.equal(result.path, projectConfig);
+});
+
+test("resolveTrackingConfig falls back to ICA_HOME system config when project is missing", async () => {
+  const systemConfig = path.join("/workspace/home/.ica", "tracking.config.json");
+  const deps = createDeps([systemConfig]);
+  const result = await resolveTrackingConfig(deps);
+
+  assert.equal(result.source, "system");
+  assert.equal(result.path, systemConfig);
+});
+
+test("resolveTrackingConfig reports missing config and computes fallback provider", async () => {
+  const deps = createDeps([]);
+  const result = await resolveTrackingConfig(deps, {
+    detectGithub: () => true,
+  });
+
+  assert.equal(result.source, "none");
+  assert.equal(result.path, null);
+  assert.equal(result.missingConfig, true);
+  assert.equal(result.fallbackProvider as TrackingProvider, "github");
+});
+
+test("resolveTrackingConfig defaults fallback provider to file-based when github is unavailable", async () => {
+  const deps = createDeps([]);
+  const result = await resolveTrackingConfig(deps, {
+    detectGithub: () => false,
+  });
+
+  assert.equal(result.fallbackProvider as TrackingProvider, "file-based");
+});
+
+test("resolveTrackingConfig checks codex then claude agent-home fallbacks", async () => {
+  const codexConfig = path.join("/workspace/home", ".codex", "tracking.config.json");
+  const claudeConfig = path.join("/workspace/home", ".claude", "tracking.config.json");
+  const deps = createDeps([codexConfig, claudeConfig]);
+  const result = await resolveTrackingConfig(deps);
+
+  assert.equal(result.source, "agent-home");
+  assert.equal(result.path, codexConfig);
+});
+
+test("resolveTrackingConfig uses file-based fallback when issue tracking is disabled", async () => {
+  const projectConfig = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const deps = createDepsWithContents({
+    [projectConfig]: JSON.stringify({
+      issue_tracking: {
+        enabled: false,
+        provider: "github",
+      },
+    }),
+  });
+
+  const result = await resolveTrackingConfig(deps, {
+    detectGithub: () => true,
+  });
+
+  assert.equal(result.path, projectConfig);
+  assert.equal(result.fallbackProvider, "file-based");
+});
+
+test("resolveTrackingConfig emits diagnostics when selected config JSON is invalid", async () => {
+  const projectConfig = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const deps = createDepsWithContents({
+    [projectConfig]: "{ invalid json",
+  });
+
+  const result = await resolveTrackingConfig(deps, {
+    detectGithub: () => false,
+  });
+
+  assert.equal(result.path, projectConfig);
+  assert.equal(result.config, null);
+  assert.equal(result.fallbackProvider, "file-based");
+  assert.ok(result.diagnostics.some((line: string) => line.includes("Invalid JSON")));
+});
+
+test("resolveTrackingConfig tolerates unset ICA_HOME and still checks agent-home candidates", async () => {
+  const claudeConfig = path.join(os.homedir(), ".claude", "tracking.config.json");
+  const deps = createDeps([claudeConfig]);
+  deps.icaHome = undefined;
+  deps.homeDir = os.homedir();
+  deps.pathExists = async (targetPath: string) => path.resolve(targetPath) === path.resolve(claudeConfig);
+
+  const result = await resolveTrackingConfig(deps);
+  assert.equal(result.path, claudeConfig);
+  assert.equal(result.source, "agent-home");
+});
+
+test("ensureTrackingConfig asks scope and creates project config when user opts out of existing system config", async () => {
+  const systemConfig = path.join("/workspace/home/.ica", "tracking.config.json");
+  const { deps, writes } = createEnsureDeps({
+    [systemConfig]: JSON.stringify({
+      issue_tracking: { enabled: true, provider: "github" },
+      tdd: { enabled: false },
+    }),
+  });
+
+  let scopePromptCount = 0;
+  const ensured = await ensureTrackingConfig(deps, {
+    detectGithub: () => true,
+    prompts: {
+      selectScope: async () => {
+        scopePromptCount += 1;
+        return "project";
+      },
+      selectProvider: async () => "file-based",
+    },
+  });
+
+  const projectConfigPath = path.join("/workspace/project", ".agent", "tracking.config.json");
+  assert.equal(scopePromptCount, 1);
+  assert.equal(ensured.path, projectConfigPath);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.targetPath, projectConfigPath);
+  assert.equal(ensured.config?.issue_tracking?.provider, "file-based");
+  assert.equal(ensured.config?.tdd?.enabled, false);
+});
+
+test("ensureTrackingConfig asks backend and creates system config when none exists", async () => {
+  const { deps, writes } = createEnsureDeps({});
+
+  const ensured = await ensureTrackingConfig(deps, {
+    detectGithub: () => false,
+    prompts: {
+      selectProvider: async () => "github",
+    },
+  });
+
+  const systemConfigPath = path.join("/workspace/home/.ica", "tracking.config.json");
+  assert.equal(ensured.path, systemConfigPath);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.targetPath, systemConfigPath);
+
+  const persisted = JSON.parse(writes[0]?.content || "{}") as {
+    issue_tracking?: { enabled?: boolean; provider?: string };
+    tdd?: { enabled?: boolean };
+  };
+  assert.equal(persisted.issue_tracking?.enabled, true);
+  assert.equal(persisted.issue_tracking?.provider, "github");
+  assert.equal(persisted.tdd?.enabled, false);
+});
+
+test("ensureTddPreference persists missing tdd.enabled default on first TDD invocation", async () => {
+  const projectConfigPath = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const { deps, writes } = createEnsureDeps({
+    [projectConfigPath]: JSON.stringify({
+      issue_tracking: { enabled: true, provider: "github" },
+    }),
+  });
+
+  const resolution = await resolveTrackingConfig(deps, { detectGithub: () => true });
+  const tdd = await ensureTddPreference(deps, {
+    resolution,
+    tddSkillActive: true,
+    prompts: {
+      selectDefaultEnabled: async () => true,
+      selectApplyForScope: async () => true,
+    },
+  });
+
+  assert.equal(tdd.defaultEnabled, true);
+  assert.equal(tdd.applyForScope, true);
+  assert.equal(tdd.persistedDefault, true);
+  assert.equal(writes.length, 1);
+  const persisted = JSON.parse(writes[0]?.content || "{}") as { tdd?: { enabled?: boolean } };
+  assert.equal(persisted.tdd?.enabled, true);
+});
+
+test("ensureTddPreference allows scope override without mutating persisted default", async () => {
+  const projectConfigPath = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const { deps, writes } = createEnsureDeps({
+    [projectConfigPath]: JSON.stringify({
+      issue_tracking: { enabled: true, provider: "github" },
+      tdd: { enabled: true },
+    }),
+  });
+
+  const resolution = await resolveTrackingConfig(deps, { detectGithub: () => true });
+  const tdd = await ensureTddPreference(deps, {
+    resolution,
+    tddSkillActive: true,
+    prompts: {
+      selectApplyForScope: async () => false,
+    },
+  });
+
+  assert.equal(tdd.defaultEnabled, true);
+  assert.equal(tdd.applyForScope, false);
+  assert.equal(tdd.persistedDefault, false);
+  assert.equal(writes.length, 0);
+});
+
+test("integration: bootstrap + TDD default persistence + run-scope override", async () => {
+  const { deps, writes } = createEnsureDeps({});
+
+  const ensured = await ensureTrackingConfig(deps, {
+    detectGithub: () => true,
+    prompts: {
+      selectProvider: async () => "github",
+    },
+  });
+  assert.equal(ensured.path, path.join("/workspace/home/.ica", "tracking.config.json"));
+
+  const tdd = await ensureTddPreference(deps, {
+    resolution: ensured,
+    tddSkillActive: true,
+    prompts: {
+      selectDefaultEnabled: async () => true,
+      selectApplyForScope: async () => true,
+    },
+  });
+
+  assert.equal(tdd.defaultEnabled, false);
+  assert.equal(tdd.applyForScope, true);
+  assert.equal(tdd.persistedDefault, false);
+  assert.equal(writes.length, 1);
+});
+
+test("updateTrackingProvider changes provider in persisted config", async () => {
+  const projectConfigPath = path.join("/workspace/project", ".agent", "tracking.config.json");
+  const { deps, writes } = createEnsureDeps({
+    [projectConfigPath]: JSON.stringify({
+      issue_tracking: { enabled: true, provider: "github" },
+      tdd: { enabled: true },
+    }),
+  });
+
+  const updated = await updateTrackingProvider(deps, projectConfigPath, "file-based");
+  assert.equal(updated.issue_tracking?.provider, "file-based");
+  assert.equal(writes.length, 1);
+
+  const persisted = JSON.parse(writes[0]?.content || "{}") as {
+    issue_tracking?: { provider?: string };
+  };
+  assert.equal(persisted.issue_tracking?.provider, "file-based");
+});


### PR DESCRIPTION
## Summary
- add a new tracking config core module for config resolution, bootstrap, and updates
- implement persisted `tdd.enabled` default handling plus per-run scope override behavior
- add contract-level installer tests for precedence, prompt/persistence flow, and integration scenarios

## Changes
- Added `/Users/karsten/Work/Development/intelligentcode-ai/intelligent-code-agents/src/installer-core/trackingConfig.ts`.
- Added `/Users/karsten/Work/Development/intelligentcode-ai/intelligent-code-agents/tests/installer/tracking-config.test.ts`.
- Implemented:
  - config precedence: project -> ICA_HOME -> ~/.codex -> ~/.claude
  - missing-config bootstrap creation for project/system scope
  - provider fallback and provider update (`updateTrackingProvider`)
  - TDD default persistence and run-scope override (`ensureTddPreference`)

## Test Plan
- [x] `npm run test`
- [x] `npm run build:quick --silent && node --test dist/tests/installer/tracking-config.test.js`

## Breaking Changes
- None.
