### PR TITLE
feat(hooks): add hybrid HOOK.json manifest support

### DIFF
--- a/docs/hook-registration-reference.md
+++ b/docs/hook-registration-reference.md
@@ -16,6 +16,11 @@ Hooks are registered by the current installer surface:
 - `ica` CLI install flow
 - dashboard install flow
 
+## Metadata Source
+
+- Prefer `HOOK.json` for machine-readable metadata.
+- Keep `HOOK.md` for human-readable docs and backward-compatible fallback metadata.
+
 ## Version
 
 Hook system version: `v10.2+`.

--- a/docs/hook-system-guide.md
+++ b/docs/hook-system-guide.md
@@ -15,6 +15,12 @@ Hooks are registered through current installer flows:
 - `ica` CLI (`install` with Claude integration enabled)
 - installer dashboard apply operations for Claude target
 
+## Hook Package Metadata
+
+Use a hybrid format:
+- `HOOK.json` is authoritative for machine-readable metadata (targets, registrations, matcher/command data).
+- `HOOK.md` remains for human documentation and optional compatibility fallback metadata.
+
 ## Why PreToolUse Only
 
 Runtime-native orchestration handles roles/subagents; ICA hooks focus on safety and output hygiene.

--- a/src/installer-core/hookExecutor.ts
+++ b/src/installer-core/hookExecutor.ts
@@ -187,6 +187,16 @@ async function installOrSyncTarget(repoRoot: string, request: HookInstallRequest
       continue;
     }
 
+    if (!hook.compatibleTargets.includes(report.target)) {
+      report.skippedHooks.push(hook.hookId);
+      pushWarning(
+        report,
+        "HOOK_TARGET_INCOMPATIBLE",
+        `Skipped '${hook.hookId}' for target '${report.target}' (compatible targets: ${hook.compatibleTargets.join(", ")}).`,
+      );
+      continue;
+    }
+
     if (selectedNames.has(hook.hookName)) {
       report.skippedHooks.push(hook.hookId);
       pushWarning(


### PR DESCRIPTION
## Summary
- add hybrid hook metadata support with `HOOK.json` as authoritative machine manifest and `HOOK.md` as human-facing fallback
- enforce hook target compatibility at install/sync time (skip incompatible hooks with warning)
- keep CLI helper exports import-safe for tests (`require.main === module`) and retain serve helper test coverage

## Changes
- update hook catalog parsing to prefer `HOOK.json`, parse compatible targets and registrations, and keep `HOOK.md` fallback
- update hook executor to skip incompatible target installs with `HOOK_TARGET_INCOMPATIBLE`
- add installer tests for JSON metadata ingestion and target compatibility behavior
- update hook docs for hybrid manifest guidance

## Test Plan
- [x] `npm run build:quick`
- [x] `node --test dist/tests/installer/*.test.js`