### PR TITLE
fix: preserve antigravity installs and restore test assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ICA installs `SKILL.md` assets and supporting defaults into agent home directori
 - `codex` -> `~/.codex`
 - `cursor` -> `~/.cursor`
 - `gemini` -> `~/.gemini`
-- `antigravity` -> `~/.antigravity`
+- `antigravity` -> `~/.gemini/antigravity`
 
 ## Install Methods
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,14 @@ If symlink creation fails, ICA falls back to `copy` and records the effective mo
 
 ## Scope Modes
 
-- `user` scope: installs into tool home (`~/.claude`, `~/.codex`, ...)
-- `project` scope: installs into `<project>/<agent-home-dir>`
+- `user` scope: installs into tool home (`~/.claude`, `~/.codex`, `~/.gemini/antigravity`, ...)
+- `project` scope: installs into `<project>/<agent-home-dir>` (Antigravity uses `<project>/.agents`)
+
+For Antigravity installs, ICA also generates companion workflows:
+- user scope: `~/.gemini/antigravity/global_workflows/*.md`
+- project scope: `<project>/.agents/workflows/*.md`
+
+Antigravity legacy project path `.agent` remains compatibility-only; ICA now defaults to `.agents`.
 
 CLI default for project scope: when `--scope=project` is used without `--project-path`, ICA uses the current working directory.
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -64,6 +64,31 @@ Notes:
 - GitHub forbids approving your own PR (server-side rule). For self-authored PRs, approvals require a second GitHub
   identity/bot if you want this gate to pass.
 
+### GitHub-First Project Policy
+
+For a GitHub-first project, combine `ica.config.json`, `ica.workflow.json`, and tracking config so GitHub is the primary backend for both planning and merge flow:
+
+```json
+{
+  "mcp_integrations": {
+    "issue_tracking": {
+      "provider": "mcp__github",
+      "enabled": true
+    }
+  }
+}
+```
+
+```json
+{
+  "medium": { "pr_required": true, "auto_merge": true, "require_github_approval": true },
+  "large":  { "pr_required": true, "auto_merge": true, "require_github_approval": true },
+  "mega":   { "pr_required": true, "auto_merge": true, "require_github_approval": true }
+}
+```
+
+Use this pattern only if you want GitHub-native approvals on top of the ICA receipt gate. Self-authored PRs need a second approver identity or bot only when `require_github_approval` is enabled.
+
 ## Key Settings
 
 ### Autonomy + Work-Item Orchestration

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -110,8 +110,15 @@ ica serve --open=true
 
 ## Scope
 
-- User scope: `~/.claude`, `~/.codex`, `~/.cursor`, `~/.gemini`, `~/.antigravity`
+- User scope: `~/.claude`, `~/.codex`, `~/.cursor`, `~/.gemini`, `~/.gemini/antigravity`
 - Project scope: `<project>/.claude`, `<project>/.codex`, ...
+
+Antigravity project scope installs into `<project>/.agents` (skills under `<project>/.agents/skills`).
+ICA also creates Antigravity workflows for slash discovery:
+- user scope: `~/.gemini/antigravity/global_workflows`
+- project scope: `<project>/.agents/workflows`
+
+Legacy Antigravity project path `.agent` is supported for migration/compatibility only.
 
 CLI default: for `--scope=project`, if `--project-path` is omitted, ICA uses the current working directory.
 

--- a/docs/project-configuration.md
+++ b/docs/project-configuration.md
@@ -28,6 +28,12 @@ Preferred project-local location for workflow defaults per tier.
 Start from:
 - `ica.workflow.default.json`
 
+## Antigravity Notes
+
+Antigravity workspace customizations default to `.agents` (with legacy `.agent` compatibility):
+- skills: `./.agents/skills/`
+- workflows: `./.agents/workflows/`
+
 ## Claude Integration (Optional)
 
 When Claude integration is enabled, ICA may manage:

--- a/docs/workflow-guide.md
+++ b/docs/workflow-guide.md
@@ -1,7 +1,8 @@
 # Workflow Guide (v10.2)
 
-This project is **dev-first** and **skills-gated**:
-- GitHub can require a PR, while ICA enforces “review required” via an `ICA-REVIEW-RECEIPT`.
+This project is **GitHub-first**, **dev-first**, and **skills-gated**:
+- GitHub PRs are the primary merge workflow.
+- ICA also enforces “review required” via an `ICA-REVIEW-RECEIPT`.
 - The agent performs merges itself (`gh pr merge`), never GitHub auto-merge (`--auto`).
 
 ## Branch Workflow (Dev-First)
@@ -37,17 +38,17 @@ Optional: standing approval ("auto-merge") once gates pass:
 
 ## Optional GitHub-Style Approvals
 
-By default, this repo uses **self-review-and-merge**:
-- PR required (branch protection), GitHub required approvals may remain at 0.
-- ICA Stage 3 receipt is the required review gate.
+This repo uses a **GitHub-first PR flow** with ICA Stage 3 receipts as the required review gate:
+- PR required (branch protection).
+- ICA Stage 3 receipt remains the required review gate.
+- GitHub-native approvals remain optional unless explicitly enabled in repo workflow policy or GitHub branch protection.
 
-If you want to also require a GitHub-native approval gate, set:
+If you want to add a GitHub-native approval gate, enable:
 
 - Tier default: `require_github_approval=true` in `ica.workflow.json`
 - Per-AgentTask override: `workflow.require_github_approval: true`
 
-Note: GitHub forbids approving your own PR. If you require GitHub approvals for self-authored PRs, you need a second
-GitHub identity/bot.
+Note: GitHub forbids approving your own PR. Self-authored PRs therefore require a second GitHub identity or bot only when this optional gate is enabled.
 
 ## Release Workflow
 

--- a/ica.config.json
+++ b/ica.config.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "./src/schemas/ica.config.schema.json",
+  "version": "1.0.0",
+  "description": "Project-level ICA policy for intelligent-code-agents",
+  "autonomy": {
+    "level": "L3",
+    "system_level": "L3",
+    "project_level": "L3",
+    "pm_always_active": true,
+    "work_item_pipeline_enabled": true,
+    "work_item_pipeline_mode": "batch_auto",
+    "l3_settings": {
+      "max_parallel": 5,
+      "auto_discover": true,
+      "continue_on_error": true
+    }
+  },
+  "git": {
+    "privacy": true,
+    "branch_protection": true,
+    "default_branch": "main",
+    "require_pr_for_main": true,
+    "validate_commits": true,
+    "worktree_branch_behavior": "always_new",
+    "worktree_branch_prefix": "agent/"
+  },
+  "quality": {
+    "enforce_peer_review": true,
+    "testing_required": true,
+    "security_validation": true,
+    "documentation_required": true
+  },
+  "development": {
+    "testing_approach": "comprehensive",
+    "file_management_strict": true
+  },
+  "project": {
+    "repository_type": "git",
+    "release_automation": true
+  },
+  "tools": {
+    "mcp_tools_enabled": true
+  },
+  "mcp_integrations": {
+    "issue_tracking": {
+      "provider": "mcp__github",
+      "enabled": true,
+      "fallback": "file-based",
+      "config": {}
+    }
+  }
+}

--- a/ica.workflow.json
+++ b/ica.workflow.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./src/schemas/ica.workflow.schema.json",
+  "version": "1.0.0",
+  "description": "Project-level GitHub workflow policy for intelligent-code-agents",
+  "medium": {
+    "pr_required": true,
+    "merge_strategy": "feature_branch",
+    "release_automation": true,
+    "auto_merge": true,
+    "require_github_approval": false
+  },
+  "large": {
+    "pr_required": true,
+    "merge_strategy": "feature_branch",
+    "release_automation": true,
+    "auto_merge": true,
+    "require_github_approval": false,
+    "coordination_required": true
+  },
+  "mega": {
+    "pr_required": true,
+    "merge_strategy": "feature_branch",
+    "release_automation": true,
+    "auto_merge": true,
+    "require_github_approval": false,
+    "coordination_required": true,
+    "breaking_change_assessment": true
+  }
+}

--- a/scripts/discover-agent-targets.sh
+++ b/scripts/discover-agent-targets.sh
@@ -57,7 +57,7 @@ if has_dir "${home}/.gemini" || has_cmd gemini || has_dir "${home}/.config/gemin
 fi
 
 # Antigravity (best-effort; tool-specific wiring varies)
-if has_dir "${home}/.antigravity" || has_cmd antigravity; then
+if has_dir "${home}/.gemini/antigravity" || has_dir "${home}/.antigravity" || has_cmd antigravity; then
   targets+=("antigravity")
 fi
 

--- a/src/catalog/skills.catalog.json
+++ b/src/catalog/skills.catalog.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "1970-01-01T00:00:00.000Z",
   "source": "multi-source",
-  "version": "12.3.0",
+  "version": "12.3.1",
   "sources": [
     {
       "id": "official-skills",

--- a/src/installer-api/server/index.ts
+++ b/src/installer-api/server/index.ts
@@ -16,6 +16,7 @@ import { syncHookSource } from "../../installer-core/hookSync";
 import { loadHookCatalogFromSources, HookInstallSelection } from "../../installer-core/hookCatalog";
 import { executeHookOperation, HookInstallRequest, HookTargetPlatform } from "../../installer-core/hookExecutor";
 import { loadHookInstallState } from "../../installer-core/hookState";
+import { inspectInstallations } from "../../installer-core/installations";
 import { registerRepository } from "../../installer-core/repositories";
 import { redactSensitive, safeErrorMessage } from "../../installer-core/security";
 import { refreshSourcesAndHooks } from "../../installer-core/sourceRefresh";
@@ -36,15 +37,6 @@ import {
 import { dashboardServerPluginRegistry } from "../../installer-dashboard/server/pluginRegistry";
 import { createRealtimeHub } from "./realtime";
 import { createWsTicketStore } from "./wsTickets";
-
-interface InstallationSkillView {
-  name: string;
-  skillId?: string;
-  sourceId?: string;
-  installMode: string;
-  effectiveMode: string;
-  orphaned?: boolean;
-}
 
 interface InstallationHookView {
   name: string;
@@ -222,51 +214,6 @@ function asHookInstallSelection(input: unknown): HookInstallSelection[] | undefi
     }))
     .filter((item) => item.sourceId && item.hookName);
   return parsed.length > 0 ? parsed : undefined;
-}
-
-function detectLegacyInstalledSkills(installPath: string, catalogSkillNames: Set<string>): InstallationSkillView[] {
-  const skillsRoot = path.join(installPath, "skills");
-  if (!fs.existsSync(skillsRoot)) {
-    return [];
-  }
-
-  let entries: fs.Dirent[] = [];
-  try {
-    entries = fs.readdirSync(skillsRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const detected: InstallationSkillView[] = [];
-  for (const entry of entries) {
-    if (!catalogSkillNames.has(entry.name)) {
-      continue;
-    }
-
-    const skillPath = path.join(skillsRoot, entry.name);
-    let looksLikeSkill = false;
-    try {
-      const stat = fs.lstatSync(skillPath);
-      if (stat.isSymbolicLink()) {
-        const resolved = fs.realpathSync(skillPath);
-        looksLikeSkill = fs.existsSync(path.join(resolved, "SKILL.md"));
-      } else if (stat.isDirectory()) {
-        looksLikeSkill = fs.existsSync(path.join(skillPath, "SKILL.md"));
-      }
-    } catch {
-      looksLikeSkill = false;
-    }
-
-    if (looksLikeSkill) {
-      detected.push({
-        name: entry.name,
-        installMode: "unknown",
-        effectiveMode: "unknown",
-      });
-    }
-  }
-
-  return detected.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function detectLegacyInstalledHooks(installPath: string, catalogHookNames: Set<string>): InstallationHookView[] {
@@ -533,41 +480,7 @@ export async function createInstallerApiServer(options: InstallerApiServerOption
     const targets = parseTargets(query.targets);
     const resolved = resolveTargetPaths(targets, scope, projectPath);
     const catalog = await deps.loadCatalogFromSources(repoRoot, false);
-    const catalogSkillNames = new Set(catalog.skills.map((skill) => skill.skillName));
-    const activeSourceIds = new Set(catalog.sources.map((source) => source.id));
-
-    const rows = await Promise.all(
-      resolved.map(async (entry) => {
-        const state = await loadInstallState(entry.installPath);
-        const managedSkills: InstallationSkillView[] =
-          state?.managedSkills.map((skill) => ({
-            name: skill.name,
-            skillId: skill.skillId,
-            sourceId: skill.sourceId,
-            installMode: skill.installMode,
-            effectiveMode: skill.effectiveMode,
-            orphaned: skill.orphaned || (skill.sourceId ? !activeSourceIds.has(skill.sourceId) : false),
-          })) || [];
-        const skillsByName = new Map(managedSkills.map((skill) => [skill.name, skill]));
-        const detected = detectLegacyInstalledSkills(entry.installPath, catalogSkillNames);
-        for (const skill of detected) {
-          if (!skillsByName.has(skill.name)) {
-            skillsByName.set(skill.name, skill);
-          }
-        }
-        const combinedSkills = Array.from(skillsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
-
-        return {
-          target: entry.target,
-          installPath: entry.installPath,
-          scope: entry.scope,
-          projectPath: entry.projectPath,
-          installed: Boolean(state) || combinedSkills.length > 0,
-          managedSkills: combinedSkills,
-          updatedAt: state?.updatedAt,
-        };
-      }),
-    );
+    const rows = await inspectInstallations(resolved, catalog);
 
     return { installations: rows };
   });

--- a/src/installer-cli/index.ts
+++ b/src/installer-cli/index.ts
@@ -22,7 +22,7 @@ import { loadHookInstallState } from "../installer-core/hookState";
 import { registerRepository } from "../installer-core/repositories";
 import { contributeOfficialSkillBundle, publishSkillBundle, validateSkillBundle } from "../installer-core/skillPublish";
 import { refreshSourcesAndHooks } from "../installer-core/sourceRefresh";
-import { loadInstallState } from "../installer-core/state";
+import { inspectInstallations } from "../installer-core/installations";
 import { parseTargets, resolveTargetPaths } from "../installer-core/targets";
 import { checkForAppUpdate } from "../installer-core/updateCheck";
 import { findRepoRoot } from "../installer-core/repo";
@@ -850,16 +850,19 @@ async function runList(options: Record<string, string | boolean>): Promise<void>
   const projectPath = stringOption(options, "project-path", "") || undefined;
   const targets = parseTargetsStrict(stringOption(options, "targets", ""));
   const resolved = resolveTargetPaths(targets, scope, projectPath, stringOption(options, "agent-dir-name", "") || undefined);
+  const repoRoot = findRepoRoot(__dirname);
+  const catalog = await loadCatalogFromSources(repoRoot, false);
+  const installations = await inspectInstallations(resolved, catalog);
 
-  const rows: Array<{ target: TargetPlatform; installPath: string; managedSkills: string[]; updatedAt?: string }> = [];
+  const rows: Array<{ target: TargetPlatform; installPath: string; managedSkills: string[]; managedWorkflows: string[]; updatedAt?: string }> = [];
 
-  for (const target of resolved) {
-    const state = await loadInstallState(target.installPath);
+  for (const target of installations) {
     rows.push({
       target: target.target,
       installPath: target.installPath,
-      managedSkills: (state?.managedSkills || []).map((skill) => skill.skillId || skill.name),
-      updatedAt: state?.updatedAt,
+      managedSkills: target.managedSkills.map((skill) => skill.skillId || skill.name),
+      managedWorkflows: target.managedWorkflows.map((workflow) => workflow.name),
+      updatedAt: target.updatedAt,
     });
   }
 
@@ -871,6 +874,7 @@ async function runList(options: Record<string, string | boolean>): Promise<void>
   for (const row of rows) {
     output.write(`${row.target}: ${row.installPath}\n`);
     output.write(`  Skills: ${row.managedSkills.length > 0 ? row.managedSkills.join(", ") : "(none)"}\n`);
+    output.write(`  Workflows: ${row.managedWorkflows.length > 0 ? row.managedWorkflows.join(", ") : "(none)"}\n`);
     if (row.updatedAt) {
       output.write(`  Updated: ${row.updatedAt}\n`);
     }
@@ -952,7 +956,9 @@ async function runOperation(command: OperationKind, options: Record<string, stri
   for (const target of report.targets) {
     output.write(`\n[${target.target}] ${target.operation} -> ${target.installPath}\n`);
     output.write(`  applied: ${target.appliedSkills.join(", ") || "(none)"}\n`);
+    output.write(`  applied workflows: ${target.appliedWorkflows.join(", ") || "(none)"}\n`);
     output.write(`  removed: ${target.removedSkills.join(", ") || "(none)"}\n`);
+    output.write(`  removed workflows: ${target.removedWorkflows.join(", ") || "(none)"}\n`);
     output.write(`  skipped: ${target.skippedSkills.join(", ") || "(none)"}\n`);
 
     if (target.warnings.length > 0) {

--- a/src/installer-core/antigravity.ts
+++ b/src/installer-core/antigravity.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import { InstallScope } from "./types";
+
+export function workflowNameFromSkillName(skillName: string): string {
+  const normalized = skillName.trim().toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+  return normalized || "workflow";
+}
+
+export function antigravityWorkflowDirectory(scope: InstallScope): string {
+  return scope === "user" ? "global_workflows" : "workflows";
+}
+
+export function antigravityWorkflowPath(basePath: string, scope: InstallScope): string {
+  return path.join(basePath, antigravityWorkflowDirectory(scope));
+}

--- a/src/installer-core/constants.ts
+++ b/src/installer-core/constants.ts
@@ -8,7 +8,7 @@ export const TARGET_HOME_DIR: Record<TargetPlatform, string> = {
   codex: ".codex",
   cursor: ".cursor",
   gemini: ".gemini",
-  antigravity: ".antigravity",
+  antigravity: path.join(".gemini", "antigravity"),
 };
 
 export const BASELINE_DIRECTORIES = ["behaviors", "roles", "agenttask-templates"];

--- a/src/installer-core/executor.ts
+++ b/src/installer-core/executor.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
 import { BASELINE_DIRECTORIES, BASELINE_FILES, TARGET_HOME_DIR } from "./constants";
+import { antigravityWorkflowPath, workflowNameFromSkillName } from "./antigravity";
 import { applyClaudeIntegration } from "./claudeIntegration";
 import { loadCatalogFromSources } from "./catalog";
 import { findSkillById, resolveInstallSelections } from "./catalogMultiSource";
-import { copyPath, ensureDir, pathExists, removePath, trySymlinkDirectory } from "./fs";
+import { copyPath, ensureDir, pathExists, removePath, trySymlinkDirectory, writeText } from "./fs";
 import { mergeMcpConfig } from "./mcp";
 import { computePlannerDelta } from "./planner";
 import { assertPathWithin, redactSensitive } from "./security";
@@ -13,6 +14,7 @@ import {
   InstallRequest,
   InstallState,
   ManagedSkillState,
+  ManagedWorkflowState,
   OperationReport,
   SkillCatalog,
   ResolvedTargetPath,
@@ -40,34 +42,78 @@ export interface ExecuteOperationOptions {
   hooks?: ExecuteOperationHooks;
 }
 
-function buildBaselinePaths(installPath: string): string[] {
-  const dirs = BASELINE_DIRECTORIES.map((dirName) => path.join(installPath, dirName));
-  const files = BASELINE_FILES.map((fileName) => path.join(installPath, fileName));
-  return [...dirs, ...files, path.join(installPath, "skills"), path.join(installPath, "logs"), path.join(installPath, "ica.config.json")];
+function isAntigravityTarget(resolved: ResolvedTargetPath): boolean {
+  return resolved.target === "antigravity";
 }
 
-async function installBaseline(repoRoot: string, installPath: string, configFile?: string): Promise<void> {
-  await ensureDir(installPath);
-  await ensureDir(path.join(installPath, "skills"));
-  await ensureDir(path.join(installPath, "logs"));
+function workflowDescriptionForSkill(skillName: string, description?: string): string {
+  const normalized = (description || "").replace(/\s+/g, " ").trim();
+  if (normalized.length > 0) {
+    return normalized;
+  }
+  return `Use the ${skillName} skill`;
+}
+
+function buildAntigravityWorkflowMarkdown(skillName: string, description: string): string {
+  return `---
+description: ${description}
+---
+
+Use the ${skillName} skill for this task.
+
+Follow the ${skillName} skill instructions and use its bundled resources (scripts, references, and assets) when relevant.
+
+If ${skillName} is not a good fit, explain why and suggest the best matching skill.
+`;
+}
+
+async function writeAntigravityWorkflow(
+  resolved: ResolvedTargetPath,
+  skillName: string,
+  description: string,
+): Promise<{ name: string; destinationPath: string }> {
+  const workflowName = workflowNameFromSkillName(skillName);
+  const destinationPath = path.join(resolved.workflowsPath, `${workflowName}.md`);
+  assertPathWithin(resolved.installPath, destinationPath);
+  await writeText(destinationPath, buildAntigravityWorkflowMarkdown(skillName, description));
+  return { name: workflowName, destinationPath };
+}
+
+function buildBaselinePaths(resolved: ResolvedTargetPath): string[] {
+  const dirs = BASELINE_DIRECTORIES.map((dirName) => path.join(resolved.installPath, dirName));
+  const files = BASELINE_FILES.map((fileName) => path.join(resolved.installPath, fileName));
+  const paths = [...dirs, ...files, resolved.skillsPath, path.join(resolved.installPath, "logs"), path.join(resolved.installPath, "ica.config.json")];
+  if (isAntigravityTarget(resolved)) {
+    paths.push(resolved.workflowsPath);
+  }
+  return paths;
+}
+
+async function installBaseline(repoRoot: string, resolved: ResolvedTargetPath, configFile?: string): Promise<void> {
+  await ensureDir(resolved.installPath);
+  await ensureDir(resolved.skillsPath);
+  await ensureDir(path.join(resolved.installPath, "logs"));
+  if (isAntigravityTarget(resolved)) {
+    await ensureDir(resolved.workflowsPath);
+  }
 
   for (const directory of BASELINE_DIRECTORIES) {
     const source = path.join(repoRoot, "src", directory);
-    const destination = path.join(installPath, directory);
+    const destination = path.join(resolved.installPath, directory);
     await removePath(destination);
     await copyPath(source, destination);
   }
 
   const versionSource = path.join(repoRoot, "src", "VERSION");
-  await copyPath(versionSource, path.join(installPath, "VERSION"));
+  await copyPath(versionSource, path.join(resolved.installPath, "VERSION"));
 
   const defaultConfigSource = path.join(repoRoot, "ica.config.default.json");
-  await copyPath(defaultConfigSource, path.join(installPath, "ica.config.default.json"));
+  await copyPath(defaultConfigSource, path.join(resolved.installPath, "ica.config.default.json"));
 
   const defaultWorkflowSource = path.join(repoRoot, "ica.workflow.default.json");
-  await copyPath(defaultWorkflowSource, path.join(installPath, "ica.workflow.default.json"));
+  await copyPath(defaultWorkflowSource, path.join(resolved.installPath, "ica.workflow.default.json"));
 
-  const targetConfig = path.join(installPath, "ica.config.json");
+  const targetConfig = path.join(resolved.installPath, "ica.config.json");
   if (configFile) {
     await copyPath(path.resolve(configFile), targetConfig);
   } else if (!(await pathExists(targetConfig))) {
@@ -116,6 +162,249 @@ async function removeTrackedPath(installPath: string, candidatePath: string): Pr
   await removePath(candidatePath);
 }
 
+async function moveManagedPath(fromBasePath: string, toBasePath: string, fromPath: string, toPath: string): Promise<void> {
+  assertPathWithin(fromBasePath, fromPath);
+  assertPathWithin(toBasePath, toPath);
+  if (!(await pathExists(fromPath))) {
+    return;
+  }
+  if (await pathExists(toPath)) {
+    throw new Error(`Antigravity migration conflict: '${toPath}' already exists. Resolve the conflict and rerun the operation.`);
+  }
+  await copyPath(fromPath, toPath);
+  await removePath(fromPath);
+}
+
+interface PlannedPathMove {
+  fromPath: string;
+  toPath: string;
+}
+
+interface PlannedWorkflow {
+  name: string;
+  skillName: string;
+  skillId: string;
+  sourceId: string;
+  destinationPath: string;
+}
+
+interface LegacyAntigravityMigrationPlan {
+  legacyInstallPath: string;
+  reconciledLegacyState: InstallState;
+  migratedSkills: ManagedSkillState[];
+  skillMoves: PlannedPathMove[];
+  baselineMoves: PlannedPathMove[];
+  migratedBaselinePaths: string[];
+  workflows: PlannedWorkflow[];
+  legacyWorkflowRemovals: string[];
+}
+
+function antigravityMigrationLabel(resolved: ResolvedTargetPath, legacyInstallPath: string): string {
+  return resolved.scope === "user"
+    ? `'${legacyInstallPath}' to '${resolved.installPath}'`
+    : "'.agent' to '.agents'";
+}
+
+async function ensureMigrationDestinationsAvailable(resolved: ResolvedTargetPath, destinations: string[]): Promise<void> {
+  for (const destinationPath of Array.from(new Set(destinations))) {
+    assertPathWithin(resolved.installPath, destinationPath);
+    if (await pathExists(destinationPath)) {
+      throw new Error(`Antigravity migration conflict: '${destinationPath}' already exists. Resolve the conflict and rerun the operation.`);
+    }
+  }
+}
+
+function buildLegacyAntigravityMigrationPlan(
+  resolved: ResolvedTargetPath,
+  legacyInstallPath: string,
+  reconciledLegacyState: InstallState,
+): LegacyAntigravityMigrationPlan {
+  const skillMoves: PlannedPathMove[] = [];
+  const migratedSkills: ManagedSkillState[] = [];
+  for (const managed of reconciledLegacyState.managedSkills) {
+    const relativePath = path.relative(legacyInstallPath, managed.destinationPath);
+    const destinationPath = path.join(resolved.installPath, relativePath);
+    skillMoves.push({
+      fromPath: managed.destinationPath,
+      toPath: destinationPath,
+    });
+    migratedSkills.push({
+      ...managed,
+      destinationPath,
+    });
+  }
+
+  const baselineMoves: PlannedPathMove[] = [];
+  const migratedBaselinePaths: string[] = [];
+  const legacySkillsRoot = path.join(legacyInstallPath, "skills");
+  const legacyWorkflowsRoot = antigravityWorkflowPath(legacyInstallPath, resolved.scope);
+  for (const baselinePath of reconciledLegacyState.managedBaselinePaths || []) {
+    const relativePath = path.relative(legacyInstallPath, baselinePath);
+    const destinationPath = path.join(resolved.installPath, relativePath);
+    migratedBaselinePaths.push(destinationPath);
+    if (baselinePath === legacySkillsRoot || baselinePath === legacyWorkflowsRoot) {
+      continue;
+    }
+    baselineMoves.push({
+      fromPath: baselinePath,
+      toPath: destinationPath,
+    });
+  }
+
+  const workflows: PlannedWorkflow[] = [];
+  const legacyWorkflowRemovals = new Set<string>();
+  for (const managed of migratedSkills) {
+    const skillName = managed.skillName || managed.name;
+    const workflowName = workflowNameFromSkillName(skillName);
+    workflows.push({
+      name: workflowName,
+      skillName,
+      skillId: managed.skillId,
+      sourceId: managed.sourceId,
+      destinationPath: path.join(resolved.workflowsPath, `${workflowName}.md`),
+    });
+
+    const trackedWorkflows = (reconciledLegacyState.managedWorkflows || []).filter((workflow) => workflow.skillId === managed.skillId);
+    if (trackedWorkflows.length > 0) {
+      for (const workflow of trackedWorkflows) {
+        legacyWorkflowRemovals.add(workflow.destinationPath);
+      }
+    } else {
+      legacyWorkflowRemovals.add(path.join(legacyWorkflowsRoot, `${workflowName}.md`));
+    }
+  }
+
+  return {
+    legacyInstallPath,
+    reconciledLegacyState,
+    migratedSkills,
+    skillMoves,
+    baselineMoves,
+    migratedBaselinePaths,
+    workflows,
+    legacyWorkflowRemovals: Array.from(legacyWorkflowRemovals),
+  };
+}
+
+async function migrateLegacyAntigravityInstall(
+  resolved: ResolvedTargetPath,
+  report: TargetOperationReport,
+  catalog: SkillCatalog,
+): Promise<void> {
+  if (!isAntigravityTarget(resolved)) {
+    return;
+  }
+  const legacyPaths = resolved.legacyInstallPaths || [];
+  const legacyInstallPath = legacyPaths[0];
+  if (!legacyInstallPath) {
+    return;
+  }
+
+  const newStatePath = getStatePath(resolved.installPath);
+  const hasNewState = await pathExists(newStatePath);
+  const hasNewPath = await pathExists(resolved.installPath);
+  const legacyPathPresence = await Promise.all(legacyPaths.map(async (legacyPath) => ({ legacyPath, exists: await pathExists(legacyPath) })));
+
+  if (legacyPathPresence.some((entry) => entry.exists) && hasNewPath && hasNewState) {
+    pushWarning(
+      report,
+      "LEGACY_ANTIGRAVITY_PATH_PRESENT",
+      resolved.scope === "user"
+        ? "Both '~/.gemini/antigravity' and legacy '~/.antigravity' paths exist. ICA uses '~/.gemini/antigravity' and leaves unknown legacy files untouched."
+        : "Both '.agents' and legacy '.agent' paths exist. ICA uses '.agents' and leaves unknown legacy files untouched.",
+    );
+  }
+
+  if (hasNewState) {
+    return;
+  }
+
+  let sourceLegacyInstallPath: string | undefined;
+  let legacyState: InstallState | null = null;
+  for (const legacyPath of legacyPaths) {
+    const state = await loadInstallState(legacyPath);
+    if (state) {
+      sourceLegacyInstallPath = legacyPath;
+      legacyState = state;
+      break;
+    }
+  }
+
+  if (!legacyState) {
+    return;
+  }
+  const effectiveLegacyInstallPath = sourceLegacyInstallPath || legacyInstallPath;
+  const reconciledLegacyState = reconcileLegacyManagedSkills(legacyState, catalog);
+  const plan = buildLegacyAntigravityMigrationPlan(resolved, effectiveLegacyInstallPath, reconciledLegacyState);
+  await ensureMigrationDestinationsAvailable(
+    resolved,
+    [
+      ...plan.skillMoves.map((move) => move.toPath),
+      ...plan.baselineMoves.map((move) => move.toPath),
+      ...plan.workflows.map((workflow) => workflow.destinationPath),
+    ],
+  );
+
+  await ensureDir(resolved.installPath);
+  await ensureDir(resolved.skillsPath);
+  await ensureDir(resolved.workflowsPath);
+
+  for (const move of plan.skillMoves) {
+    await moveManagedPath(plan.legacyInstallPath, resolved.installPath, move.fromPath, move.toPath);
+  }
+  for (const move of plan.baselineMoves) {
+    await moveManagedPath(plan.legacyInstallPath, resolved.installPath, move.fromPath, move.toPath);
+  }
+
+  const migratedWorkflows: ManagedWorkflowState[] = [];
+  for (const workflowPlan of plan.workflows) {
+    const catalogSkill = catalog.skills.find(
+      (entry) => entry.skillId === workflowPlan.skillId || entry.skillName === workflowPlan.skillName || entry.name === workflowPlan.skillName,
+    );
+    const workflow = await writeAntigravityWorkflow(
+      resolved,
+      workflowPlan.skillName,
+      workflowDescriptionForSkill(workflowPlan.skillName, catalogSkill?.description),
+    );
+    migratedWorkflows.push({
+      name: workflow.name,
+      skillName: workflowPlan.skillName,
+      skillId: workflowPlan.skillId,
+      sourceId: workflowPlan.sourceId,
+      installMode: "copy",
+      effectiveMode: "copy",
+      destinationPath: workflow.destinationPath,
+    });
+  }
+  for (const legacyWorkflowPath of plan.legacyWorkflowRemovals) {
+    if (await pathExists(legacyWorkflowPath)) {
+      await removeTrackedPath(plan.legacyInstallPath, legacyWorkflowPath);
+    }
+  }
+
+  const migratedState = appendHistory(
+    {
+      ...plan.reconciledLegacyState,
+      target: resolved.target,
+      scope: resolved.scope,
+      projectPath: resolved.projectPath,
+      managedSkills: plan.migratedSkills.sort((a, b) => (a.skillId || a.name).localeCompare(b.skillId || b.name)),
+      managedWorkflows: migratedWorkflows.sort((a, b) => a.name.localeCompare(b.name)),
+      managedBaselinePaths: Array.from(new Set(plan.migratedBaselinePaths)),
+    },
+    "sync",
+    `Migrated legacy Antigravity install from ${antigravityMigrationLabel(resolved, plan.legacyInstallPath)}.`,
+  );
+  await saveInstallState(resolved.installPath, migratedState);
+  await removeTrackedPath(plan.legacyInstallPath, getStatePath(plan.legacyInstallPath));
+
+  pushWarning(
+    report,
+    "ANTIGRAVITY_LEGACY_MIGRATED",
+    `Migrated ICA-managed Antigravity assets from ${antigravityMigrationLabel(resolved, plan.legacyInstallPath)} and regenerated companion workflows.`,
+  );
+}
+
 async function uninstallTarget(
   request: InstallRequest,
   resolved: ResolvedTargetPath,
@@ -136,20 +425,46 @@ async function uninstallTarget(
   const selections = resolveInstallSelections(catalog, request.skillSelections, request.skills);
   const selected = new Set(selections.map((selection) => selection.skillId));
   const removeAll = selections.length === 0;
+  const removedSkillIds = new Set<string>();
+  const removedWorkflowNames = new Set<string>();
 
   for (const managed of state.managedSkills) {
     const managedId = managed.skillId || managed.name;
     if (!removeAll && !selected.has(managedId) && !selected.has(managed.name)) continue;
     await removeTrackedPath(resolved.installPath, managed.destinationPath);
     report.removedSkills.push(managedId);
+    removedSkillIds.add(managedId);
+
+    const trackedWorkflows = (state.managedWorkflows || []).filter((workflow) => workflow.skillId === managedId);
+    for (const workflow of trackedWorkflows) {
+      if (await pathExists(workflow.destinationPath)) {
+        await removeTrackedPath(resolved.installPath, workflow.destinationPath);
+      }
+      report.removedWorkflows.push(workflow.name);
+      removedWorkflowNames.add(workflow.name);
+    }
+
+    if (isAntigravityTarget(resolved) && trackedWorkflows.length === 0) {
+      const fallbackWorkflowName = workflowNameFromSkillName(managed.skillName || managed.name);
+      const fallbackWorkflowPath = path.join(resolved.workflowsPath, `${fallbackWorkflowName}.md`);
+      if (await pathExists(fallbackWorkflowPath)) {
+        await removeTrackedPath(resolved.installPath, fallbackWorkflowPath);
+        report.removedWorkflows.push(fallbackWorkflowName);
+        removedWorkflowNames.add(fallbackWorkflowName);
+      }
+    }
   }
 
   const removedSet = new Set(report.removedSkills);
   const remainingSkills = state.managedSkills.filter((managed) => !removedSet.has(managed.skillId || managed.name));
+  const remainingWorkflows = (state.managedWorkflows || []).filter(
+    (managed) => !removedSkillIds.has(managed.skillId) && !removedWorkflowNames.has(managed.name),
+  );
 
   let updatedState: InstallState = {
     ...state,
     managedSkills: remainingSkills,
+    managedWorkflows: remainingWorkflows,
   };
 
   if (removeAll) {
@@ -167,7 +482,11 @@ async function uninstallTarget(
       await removeTrackedPath(resolved.installPath, statePath);
     }
   } else {
-    updatedState = appendHistory(updatedState, "uninstall", `Removed ${report.removedSkills.length} skill(s)`);
+    updatedState = appendHistory(
+      updatedState,
+      "uninstall",
+      `Removed ${report.removedSkills.length} skill(s), ${report.removedWorkflows.length} workflow(s)`,
+    );
     await saveInstallState(resolved.installPath, updatedState);
   }
 }
@@ -179,7 +498,7 @@ async function installOrSyncTarget(
   report: TargetOperationReport,
   catalog: SkillCatalog,
 ): Promise<void> {
-  await installBaseline(repoRoot, resolved.installPath, request.configFile);
+  await installBaseline(repoRoot, resolved, request.configFile);
 
   const rawState = (await loadInstallState(resolved.installPath)) ||
     createEmptyState({
@@ -195,16 +514,45 @@ async function installOrSyncTarget(
   const removeUnselected = request.operation === "sync" || Boolean(request.removeUnselected);
   const delta = computePlannerDelta(selectedSkillIds, existingState, removeUnselected);
 
-  const skillsDir = path.join(resolved.installPath, "skills");
+  const skillsDir = resolved.skillsPath;
   await ensureDir(skillsDir);
+  if (isAntigravityTarget(resolved)) {
+    await ensureDir(resolved.workflowsPath);
+  }
 
   const nextManagedSkills = [...existingState.managedSkills].filter((item) => !delta.toRemove.includes(item.skillId || item.name));
+  const nextManagedWorkflows = [...(existingState.managedWorkflows || [])].filter((item) => !delta.toRemove.includes(item.skillId));
+  const appliedWorkflowNames = new Set<string>();
+  const removedWorkflowNames = new Set<string>();
 
   for (const skillId of delta.toRemove) {
     const tracked = existingState.managedSkills.find((managed) => (managed.skillId || managed.name) === skillId);
     if (tracked) {
       await removeTrackedPath(resolved.installPath, tracked.destinationPath);
       report.removedSkills.push(skillId);
+    }
+
+    const trackedWorkflows = (existingState.managedWorkflows || []).filter((workflow) => workflow.skillId === skillId);
+    for (const workflow of trackedWorkflows) {
+      if (await pathExists(workflow.destinationPath)) {
+        await removeTrackedPath(resolved.installPath, workflow.destinationPath);
+      }
+      if (!removedWorkflowNames.has(workflow.name)) {
+        report.removedWorkflows.push(workflow.name);
+        removedWorkflowNames.add(workflow.name);
+      }
+    }
+
+    if (isAntigravityTarget(resolved) && trackedWorkflows.length === 0 && tracked) {
+      const fallbackWorkflowName = workflowNameFromSkillName(tracked.skillName || tracked.name);
+      const fallbackWorkflowPath = path.join(resolved.workflowsPath, `${fallbackWorkflowName}.md`);
+      if (await pathExists(fallbackWorkflowPath)) {
+        await removeTrackedPath(resolved.installPath, fallbackWorkflowPath);
+        if (!removedWorkflowNames.has(fallbackWorkflowName)) {
+          report.removedWorkflows.push(fallbackWorkflowName);
+          removedWorkflowNames.add(fallbackWorkflowName);
+        }
+      }
     }
   }
 
@@ -266,13 +614,75 @@ async function installOrSyncTarget(
 
     nextManagedSkills.push(managed);
     report.appliedSkills.push(skill.skillId);
+
+    if (isAntigravityTarget(resolved)) {
+      const workflow = await writeAntigravityWorkflow(
+        resolved,
+        skill.skillName,
+        workflowDescriptionForSkill(skill.skillName, skill.description),
+      );
+      const nextWorkflow: ManagedWorkflowState = {
+        name: workflow.name,
+        skillName: skill.skillName,
+        skillId: skill.skillId,
+        sourceId: skill.sourceId,
+        installMode: "copy",
+        effectiveMode: "copy",
+        destinationPath: workflow.destinationPath,
+      };
+      const existingIndex = nextManagedWorkflows.findIndex((item) => item.skillId === skill.skillId);
+      if (existingIndex >= 0) {
+        nextManagedWorkflows[existingIndex] = nextWorkflow;
+      } else {
+        nextManagedWorkflows.push(nextWorkflow);
+      }
+      if (!appliedWorkflowNames.has(workflow.name)) {
+        report.appliedWorkflows.push(workflow.name);
+        appliedWorkflowNames.add(workflow.name);
+      }
+    }
   }
 
   for (const already of delta.alreadyInstalled) {
     report.skippedSkills.push(already);
   }
 
-  const managedBaselinePaths = buildBaselinePaths(resolved.installPath);
+  if (isAntigravityTarget(resolved)) {
+    for (const selection of selections) {
+      const existing = nextManagedSkills.find((item) => item.skillId === selection.skillId);
+      const skill = findSkillById(catalog, selection.skillId);
+      const skillName = existing?.skillName || existing?.name || skill?.skillName;
+      if (!existing || !skillName) {
+        continue;
+      }
+      const workflow = await writeAntigravityWorkflow(
+        resolved,
+        skillName,
+        workflowDescriptionForSkill(skillName, skill?.description),
+      );
+      const nextWorkflow: ManagedWorkflowState = {
+        name: workflow.name,
+        skillName,
+        skillId: existing.skillId,
+        sourceId: existing.sourceId,
+        installMode: "copy",
+        effectiveMode: "copy",
+        destinationPath: workflow.destinationPath,
+      };
+      const existingIndex = nextManagedWorkflows.findIndex((item) => item.skillId === existing.skillId);
+      if (existingIndex >= 0) {
+        nextManagedWorkflows[existingIndex] = nextWorkflow;
+      } else {
+        nextManagedWorkflows.push(nextWorkflow);
+      }
+      if (!appliedWorkflowNames.has(workflow.name)) {
+        report.appliedWorkflows.push(workflow.name);
+        appliedWorkflowNames.add(workflow.name);
+      }
+    }
+  }
+
+  const managedBaselinePaths = buildBaselinePaths(resolved);
 
   if (resolved.target === "claude" && request.installClaudeIntegration !== false) {
     await applyClaudeIntegration({
@@ -302,10 +712,11 @@ async function installOrSyncTarget(
       scope: resolved.scope,
       projectPath: resolved.projectPath,
       managedSkills: nextManagedSkills.sort((a, b) => (a.skillId || a.name).localeCompare(b.skillId || b.name)),
+      managedWorkflows: nextManagedWorkflows.sort((a, b) => a.name.localeCompare(b.name)),
       managedBaselinePaths: Array.from(new Set(managedBaselinePaths)),
     },
     request.operation,
-    `Applied ${report.appliedSkills.length}, removed ${report.removedSkills.length}, skipped ${report.skippedSkills.length}`,
+    `Applied ${report.appliedSkills.length} skill(s), ${report.appliedWorkflows.length} workflow(s); removed ${report.removedSkills.length} skill(s), ${report.removedWorkflows.length} workflow(s); skipped ${report.skippedSkills.length} skill(s)`,
   );
 
   await saveInstallState(resolved.installPath, state);
@@ -317,7 +728,9 @@ function defaultTargetReport(target: TargetPlatform, installPath: string, operat
     installPath,
     operation,
     appliedSkills: [],
+    appliedWorkflows: [],
     removedSkills: [],
+    removedWorkflows: [],
     skippedSkills: [],
     warnings: [],
     errors: [],
@@ -341,6 +754,7 @@ export async function executeOperation(repoRoot: string, request: InstallRequest
     reports.push(report);
 
     try {
+      await migrateLegacyAntigravityInstall(resolved, report, catalog);
       if (request.operation === "uninstall") {
         await uninstallTarget(request, resolved, report, catalog);
       } else {

--- a/src/installer-core/installations.ts
+++ b/src/installer-core/installations.ts
@@ -1,0 +1,212 @@
+import fs from "node:fs";
+import path from "node:path";
+import { antigravityWorkflowPath, workflowNameFromSkillName } from "./antigravity";
+import { loadInstallState, reconcileLegacyManagedSkills } from "./state";
+import { InstallState, ResolvedTargetPath, SkillCatalog } from "./types";
+
+export interface InstallationSkillView {
+  name: string;
+  skillId?: string;
+  sourceId?: string;
+  installMode: string;
+  effectiveMode: string;
+  orphaned?: boolean;
+}
+
+export interface InstallationWorkflowView {
+  name: string;
+  skillId?: string;
+  sourceId?: string;
+  installMode: string;
+  effectiveMode: string;
+}
+
+export interface InstallationRow {
+  target: ResolvedTargetPath["target"];
+  installPath: string;
+  scope: ResolvedTargetPath["scope"];
+  projectPath?: string;
+  installed: boolean;
+  managedSkills: InstallationSkillView[];
+  managedWorkflows: InstallationWorkflowView[];
+  updatedAt?: string;
+}
+
+function candidateSkillRoots(target: ResolvedTargetPath): string[] {
+  const roots = [target.skillsPath];
+  if (target.target === "antigravity") {
+    for (const legacyBase of target.legacyInstallPaths || []) {
+      roots.push(path.join(legacyBase, "skills"));
+    }
+  }
+  return Array.from(new Set(roots));
+}
+
+function candidateWorkflowRoots(target: ResolvedTargetPath): string[] {
+  const roots = [target.workflowsPath];
+  if (target.target === "antigravity") {
+    for (const legacyBase of target.legacyInstallPaths || []) {
+      roots.push(antigravityWorkflowPath(legacyBase, target.scope));
+    }
+  }
+  return Array.from(new Set(roots));
+}
+
+function detectLegacyInstalledSkills(roots: string[], catalogSkillNames: Set<string>): InstallationSkillView[] {
+  const byName = new Map<string, InstallationSkillView>();
+  for (const skillsRoot of roots) {
+    if (!fs.existsSync(skillsRoot)) {
+      continue;
+    }
+
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(skillsRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!catalogSkillNames.has(entry.name) || byName.has(entry.name)) {
+        continue;
+      }
+
+      const skillPath = path.join(skillsRoot, entry.name);
+      let looksLikeSkill = false;
+      try {
+        const stat = fs.lstatSync(skillPath);
+        if (stat.isSymbolicLink()) {
+          const resolved = fs.realpathSync(skillPath);
+          looksLikeSkill = fs.existsSync(path.join(resolved, "SKILL.md"));
+        } else if (stat.isDirectory()) {
+          looksLikeSkill = fs.existsSync(path.join(skillPath, "SKILL.md"));
+        }
+      } catch {
+        looksLikeSkill = false;
+      }
+
+      if (looksLikeSkill) {
+        byName.set(entry.name, {
+          name: entry.name,
+          installMode: "unknown",
+          effectiveMode: "unknown",
+        });
+      }
+    }
+  }
+
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function detectMatchedInstalledWorkflows(roots: string[], allowedWorkflowNames: Set<string>): InstallationWorkflowView[] {
+  const byName = new Map<string, InstallationWorkflowView>();
+  for (const workflowsRoot of roots) {
+    if (!fs.existsSync(workflowsRoot)) {
+      continue;
+    }
+
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(workflowsRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() && !entry.isSymbolicLink()) {
+        continue;
+      }
+      if (!entry.name.toLowerCase().endsWith(".md")) {
+        continue;
+      }
+      const workflowName = entry.name.replace(/\.md$/i, "");
+      if (!allowedWorkflowNames.has(workflowName) || byName.has(workflowName)) {
+        continue;
+      }
+      byName.set(workflowName, {
+        name: workflowName,
+        installMode: "unknown",
+        effectiveMode: "unknown",
+      });
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function loadPreferredInstallState(
+  target: ResolvedTargetPath,
+  catalog: SkillCatalog,
+): Promise<{ state: InstallState | null; installPath: string }> {
+  const candidates = Array.from(new Set([target.installPath, ...(target.legacyInstallPaths || [])]));
+  for (const installPath of candidates) {
+    const state = await loadInstallState(installPath);
+    if (state) {
+      return {
+        state: reconcileLegacyManagedSkills(state, catalog),
+        installPath,
+      };
+    }
+  }
+
+  return {
+    state: null,
+    installPath: target.installPath,
+  };
+}
+
+export async function inspectInstallation(target: ResolvedTargetPath, catalog: SkillCatalog): Promise<InstallationRow> {
+  const catalogSkillNames = new Set(catalog.skills.flatMap((skill) => [skill.name, skill.skillName]));
+  const activeSourceIds = new Set(catalog.sources.map((source) => source.id));
+  const { state, installPath } = await loadPreferredInstallState(target, catalog);
+
+  const managedSkills: InstallationSkillView[] =
+    state?.managedSkills.map((skill) => ({
+      name: skill.name,
+      skillId: skill.skillId,
+      sourceId: skill.sourceId,
+      installMode: skill.installMode,
+      effectiveMode: skill.effectiveMode,
+      orphaned: skill.orphaned || (skill.sourceId ? !activeSourceIds.has(skill.sourceId) : false),
+    })) || [];
+  const detectedSkills = detectLegacyInstalledSkills(candidateSkillRoots(target), catalogSkillNames);
+  const skillsByName = new Map(managedSkills.map((skill) => [skill.name, skill]));
+  for (const skill of detectedSkills) {
+    if (!skillsByName.has(skill.name)) {
+      skillsByName.set(skill.name, skill);
+    }
+  }
+  const combinedSkills = Array.from(skillsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+  const managedWorkflows: InstallationWorkflowView[] =
+    state?.managedWorkflows.map((workflow) => ({
+      name: workflow.name,
+      skillId: workflow.skillId,
+      sourceId: workflow.sourceId,
+      installMode: workflow.installMode,
+      effectiveMode: workflow.effectiveMode,
+    })) || [];
+  const allowedWorkflowNames = new Set(combinedSkills.map((skill) => workflowNameFromSkillName(skill.name)));
+  const detectedWorkflows = detectMatchedInstalledWorkflows(candidateWorkflowRoots(target), allowedWorkflowNames);
+  const workflowsByName = new Map(managedWorkflows.map((workflow) => [workflow.name, workflow]));
+  for (const workflow of detectedWorkflows) {
+    if (!workflowsByName.has(workflow.name)) {
+      workflowsByName.set(workflow.name, workflow);
+    }
+  }
+  const combinedWorkflows = Array.from(workflowsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    target: target.target,
+    installPath,
+    scope: target.scope,
+    projectPath: target.projectPath,
+    installed: Boolean(state) || combinedSkills.length > 0 || combinedWorkflows.length > 0,
+    managedSkills: combinedSkills,
+    managedWorkflows: combinedWorkflows,
+    updatedAt: state?.updatedAt,
+  };
+}
+
+export async function inspectInstallations(targets: ResolvedTargetPath[], catalog: SkillCatalog): Promise<InstallationRow[]> {
+  return Promise.all(targets.map((target) => inspectInstallation(target, catalog)));
+}

--- a/src/installer-core/state.ts
+++ b/src/installer-core/state.ts
@@ -15,7 +15,14 @@ export async function loadInstallState(installPath: string): Promise<InstallStat
   }
 
   const content = await readText(statePath);
-  return JSON.parse(content) as InstallState;
+  const parsed = JSON.parse(content) as Partial<InstallState>;
+  return {
+    ...parsed,
+    managedSkills: Array.isArray(parsed.managedSkills) ? parsed.managedSkills : [],
+    managedWorkflows: Array.isArray(parsed.managedWorkflows) ? parsed.managedWorkflows : [],
+    managedBaselinePaths: Array.isArray(parsed.managedBaselinePaths) ? parsed.managedBaselinePaths : [],
+    history: Array.isArray(parsed.history) ? parsed.history : [],
+  } as InstallState;
 }
 
 export async function saveInstallState(installPath: string, state: InstallState): Promise<void> {
@@ -40,6 +47,7 @@ export function createEmptyState(params: {
     installedAt: now,
     updatedAt: now,
     managedSkills: [],
+    managedWorkflows: [],
     managedBaselinePaths: [],
     history: [],
   };
@@ -111,6 +119,7 @@ export function reconcileLegacyManagedSkills(state: InstallState, catalog: Skill
 
   return {
     ...state,
+    managedWorkflows: Array.isArray(state.managedWorkflows) ? state.managedWorkflows : [],
     managedSkills: updated,
   };
 }

--- a/src/installer-core/targets.ts
+++ b/src/installer-core/targets.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execSync } from "node:child_process";
+import { antigravityWorkflowPath } from "./antigravity";
 import { SUPPORTED_TARGETS, TARGET_HOME_DIR } from "./constants";
 import { InstallScope, ResolvedTargetPath, TargetPlatform } from "./types";
 
@@ -47,7 +48,11 @@ export function discoverTargets(): TargetPlatform[] {
     targets.push("gemini");
   }
 
-  if (hasDir(path.join(home, ".antigravity")) || hasCommand("antigravity")) {
+  if (
+    hasDir(path.join(home, ".gemini", "antigravity")) ||
+    hasDir(path.join(home, ".antigravity")) ||
+    hasCommand("antigravity")
+  ) {
     targets.push("antigravity");
   }
 
@@ -74,7 +79,11 @@ export function resolveInstallPath(
   projectPath?: string,
   agentDirName?: string,
 ): string {
-  const homeDir = agentDirName || TARGET_HOME_DIR[target];
+  const homeDir =
+    agentDirName ||
+    (target === "antigravity" && scope === "project"
+      ? ".agents"
+      : TARGET_HOME_DIR[target]);
   if (scope === "project") {
     if (!projectPath) {
       throw new Error("projectPath is required for project scope");
@@ -90,10 +99,32 @@ export function resolveTargetPaths(
   projectPath?: string,
   agentDirName?: string,
 ): ResolvedTargetPath[] {
-  return targets.map((target) => ({
-    target,
-    scope,
-    projectPath: scope === "project" ? path.resolve(projectPath || "") : undefined,
-    installPath: resolveInstallPath(target, scope, projectPath, agentDirName),
-  }));
+  return targets.map((target) => {
+    const installPath = resolveInstallPath(target, scope, projectPath, agentDirName);
+    const projectRoot = scope === "project" ? path.resolve(projectPath || "") : undefined;
+
+    if (target === "antigravity") {
+      return {
+        target,
+        scope,
+        projectPath: projectRoot,
+        installPath,
+        skillsPath: path.join(installPath, "skills"),
+        workflowsPath: antigravityWorkflowPath(installPath, scope),
+        legacyInstallPaths:
+          scope === "project"
+            ? [path.join(projectRoot || "", ".agent")]
+            : [path.join(os.homedir(), ".antigravity")],
+      };
+    }
+
+    return {
+      target,
+      scope,
+      projectPath: projectRoot,
+      installPath,
+      skillsPath: path.join(installPath, "skills"),
+      workflowsPath: path.join(installPath, "workflows"),
+    };
+  });
 }

--- a/src/installer-core/types.ts
+++ b/src/installer-core/types.ts
@@ -145,6 +145,16 @@ export interface ManagedSkillState {
   sourcePath: string;
 }
 
+export interface ManagedWorkflowState {
+  name: string;
+  skillName: string;
+  skillId: SkillIdentifier;
+  sourceId: string;
+  installMode: InstallMode;
+  effectiveMode: InstallMode;
+  destinationPath: string;
+}
+
 export interface InstallState {
   schemaVersion: string;
   installerVersion: string;
@@ -154,6 +164,7 @@ export interface InstallState {
   installedAt: string;
   updatedAt: string;
   managedSkills: ManagedSkillState[];
+  managedWorkflows: ManagedWorkflowState[];
   managedBaselinePaths: string[];
   history: OperationLogEntry[];
 }
@@ -179,7 +190,9 @@ export interface TargetOperationReport {
   installPath: string;
   operation: OperationKind;
   appliedSkills: string[];
+  appliedWorkflows: string[];
   removedSkills: string[];
+  removedWorkflows: string[];
   skippedSkills: string[];
   warnings: OperationWarning[];
   errors: OperationError[];
@@ -201,6 +214,9 @@ export interface PlannerDelta {
 export interface ResolvedTargetPath {
   target: TargetPlatform;
   installPath: string;
+  skillsPath: string;
+  workflowsPath: string;
+  legacyInstallPaths?: string[];
   scope: InstallScope;
   projectPath?: string;
 }

--- a/src/installer-dashboard/server/index.ts
+++ b/src/installer-dashboard/server/index.ts
@@ -16,6 +16,7 @@ import { syncHookSource } from "../../installer-core/hookSync";
 import { loadHookCatalogFromSources, HookInstallSelection } from "../../installer-core/hookCatalog";
 import { executeHookOperation, HookInstallRequest, HookTargetPlatform } from "../../installer-core/hookExecutor";
 import { loadHookInstallState } from "../../installer-core/hookState";
+import { inspectInstallations } from "../../installer-core/installations";
 import { registerRepository } from "../../installer-core/repositories";
 import { loadInstallState } from "../../installer-core/state";
 import { discoverTargets, resolveTargetPaths } from "../../installer-core/targets";
@@ -30,15 +31,6 @@ import {
   parseEnabledDashboardPlugins,
 } from "./plugins";
 import { dashboardServerPluginRegistry } from "./pluginRegistry";
-
-interface InstallationSkillView {
-  name: string;
-  skillId?: string;
-  sourceId?: string;
-  installMode: string;
-  effectiveMode: string;
-  orphaned?: boolean;
-}
 
 interface InstallationHookView {
   name: string;
@@ -187,51 +179,6 @@ function asHookInstallSelection(input: unknown): HookInstallSelection[] | undefi
   return parsed.length > 0 ? parsed : undefined;
 }
 
-function detectLegacyInstalledSkills(installPath: string, catalogSkillNames: Set<string>): InstallationSkillView[] {
-  const skillsRoot = path.join(installPath, "skills");
-  if (!fs.existsSync(skillsRoot)) {
-    return [];
-  }
-
-  let entries: fs.Dirent[] = [];
-  try {
-    entries = fs.readdirSync(skillsRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const detected: InstallationSkillView[] = [];
-  for (const entry of entries) {
-    if (!catalogSkillNames.has(entry.name)) {
-      continue;
-    }
-
-    const skillPath = path.join(skillsRoot, entry.name);
-    let looksLikeSkill = false;
-    try {
-      const stat = fs.lstatSync(skillPath);
-      if (stat.isSymbolicLink()) {
-        const resolved = fs.realpathSync(skillPath);
-        looksLikeSkill = fs.existsSync(path.join(resolved, "SKILL.md"));
-      } else if (stat.isDirectory()) {
-        looksLikeSkill = fs.existsSync(path.join(skillPath, "SKILL.md"));
-      }
-    } catch {
-      looksLikeSkill = false;
-    }
-
-    if (looksLikeSkill) {
-      detected.push({
-        name: entry.name,
-        installMode: "unknown",
-        effectiveMode: "unknown",
-      });
-    }
-  }
-
-  return detected.sort((a, b) => a.name.localeCompare(b.name));
-}
-
 function detectLegacyInstalledHooks(installPath: string, catalogHookNames: Set<string>): InstallationHookView[] {
   const hooksRoot = path.join(installPath, "hooks");
   if (!fs.existsSync(hooksRoot)) {
@@ -348,41 +295,7 @@ async function main(): Promise<void> {
     const targets = parseTargets(query.targets);
     const resolved = resolveTargetPaths(targets, scope, projectPath);
     const catalog = await loadCatalogFromSources(repoRoot, false);
-    const catalogSkillNames = new Set(catalog.skills.map((skill) => skill.skillName));
-    const activeSourceIds = new Set(catalog.sources.map((source) => source.id));
-
-    const rows = await Promise.all(
-      resolved.map(async (entry) => {
-        const state = await loadInstallState(entry.installPath);
-        const managedSkills: InstallationSkillView[] =
-          state?.managedSkills.map((skill) => ({
-            name: skill.name,
-            skillId: skill.skillId,
-            sourceId: skill.sourceId,
-            installMode: skill.installMode,
-            effectiveMode: skill.effectiveMode,
-            orphaned: skill.orphaned || (skill.sourceId ? !activeSourceIds.has(skill.sourceId) : false),
-          })) || [];
-        const skillsByName = new Map(managedSkills.map((skill) => [skill.name, skill]));
-        const detected = detectLegacyInstalledSkills(entry.installPath, catalogSkillNames);
-        for (const skill of detected) {
-          if (!skillsByName.has(skill.name)) {
-            skillsByName.set(skill.name, skill);
-          }
-        }
-        const combinedSkills = Array.from(skillsByName.values()).sort((a, b) => a.name.localeCompare(b.name));
-
-        return {
-          target: entry.target,
-          installPath: entry.installPath,
-          scope: entry.scope,
-          projectPath: entry.projectPath,
-          installed: Boolean(state) || combinedSkills.length > 0,
-          managedSkills: combinedSkills,
-          updatedAt: state?.updatedAt,
-        };
-      }),
-    );
+    const rows = await inspectInstallations(resolved, catalog);
 
     return { installations: rows };
   });

--- a/src/installer-dashboard/web/src/InstallerDashboard.tsx
+++ b/src/installer-dashboard/web/src/InstallerDashboard.tsx
@@ -48,6 +48,14 @@ type InstallationSkill = {
   orphaned?: boolean;
 };
 
+type InstallationWorkflow = {
+  name: string;
+  skillId?: string;
+  sourceId?: string;
+  installMode: string;
+  effectiveMode: string;
+};
+
 type InstallationRow = {
   target: Target;
   installPath: string;
@@ -55,6 +63,7 @@ type InstallationRow = {
   projectPath?: string;
   installed: boolean;
   managedSkills: InstallationSkill[];
+  managedWorkflows?: InstallationWorkflow[];
   updatedAt?: string;
 };
 
@@ -94,7 +103,9 @@ type OperationTargetReport = {
   installPath: string;
   operation: string;
   appliedSkills: string[];
+  appliedWorkflows: string[];
   removedSkills: string[];
+  removedWorkflows: string[];
   skippedSkills: string[];
   warnings: Array<{ code: string; message: string }>;
   errors: Array<{ code: string; message: string }>;

--- a/src/skills/mcp-common/scripts/ica_mcp_core.py
+++ b/src/skills/mcp-common/scripts/ica_mcp_core.py
@@ -1,0 +1,1139 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Core
+
+Shared building blocks for:
+- mcp-client (CLI)
+- mcp-proxy (local stdio MCP server that mirrors upstream tools)
+
+Responsibilities:
+- Load/merge MCP server definitions from:
+  - MCP_CONFIG (inline JSON) / MCP_CONFIG_PATH (single file override)
+  - project .mcp.json
+  - $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - ~/.claude.json fallback (compat only)
+- Expand ${ENV_VAR} placeholders
+- Token store under $ICA_HOME/mcp-tokens.json
+- OAuth flows:
+  - PKCE (explicit endpoints or OIDC discovery)
+  - Device code (explicit endpoints or OIDC discovery)
+  - Client credentials (explicit token endpoint)
+- Create MCP client sessions for stdio/sse/streamable_http
+
+This module is intentionally dependency-light (stdlib + `mcp` when used for sessions).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+import time
+import threading
+import urllib.parse
+import urllib.request
+import ipaddress
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from socketserver import TCPServer
+from typing import Any, Optional
+
+
+class DependencyError(RuntimeError):
+    pass
+
+
+def missing_dep(dep: str, extra: str = "") -> None:
+    hint = f"Missing dependency '{dep}'. Install it with: pip install {dep}"
+    if extra:
+        hint = f"{hint}. {extra}"
+    raise DependencyError(hint)
+
+
+# =============================================================================
+# ICA_HOME Resolution
+# =============================================================================
+
+def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
+    """
+    Resolve ICA_HOME (agent home directory).
+
+    Priority:
+    - ICA_HOME env var
+    - infer from installed skill layout: <ICA_HOME>/skills/<skill>/scripts/<file>.py
+    """
+    if os.environ.get("ICA_HOME"):
+        return Path(os.environ["ICA_HOME"]).expanduser()
+
+    if script_file:
+        p = Path(script_file).resolve()
+        # .../skills/<skill>/scripts/<file>
+        try:
+            if p.parents[2].name == "skills":
+                candidate = p.parents[3]
+                # Guard: avoid treating repo layout (src/skills/...) as ICA_HOME.
+                # Installed ICA homes include VERSION at the root.
+                if (candidate / "VERSION").exists():
+                    return candidate
+        except Exception:
+            return None
+
+    return None
+
+
+# =============================================================================
+# Config Loading / Merging
+# =============================================================================
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def expand_env_placeholders(value: Any) -> Any:
+    """
+    Best-effort `${VAR}` expansion for config values.
+    - Only expands when VAR is present in the process environment.
+    - Leaves unknown placeholders unchanged (so configs remain portable).
+    """
+    if isinstance(value, str):
+        def repl(match: re.Match) -> str:
+            name = match.group(1)
+            return os.environ.get(name, match.group(0))
+
+        return _ENV_VAR_PATTERN.sub(repl, value)
+
+    if isinstance(value, list):
+        return [expand_env_placeholders(v) for v in value]
+
+    if isinstance(value, dict):
+        return {k: expand_env_placeholders(v) for k, v in value.items()}
+
+    return value
+
+
+def _normalize_servers(config: dict) -> dict[str, dict[str, Any]]:
+    servers = config.get("mcpServers", config)
+    if not isinstance(servers, dict):
+        raise ValueError("Config must be an object or contain an 'mcpServers' object.")
+
+    filtered: dict[str, dict[str, Any]] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if "command" in cfg or "url" in cfg:
+            filtered[str(name)] = cfg
+    return filtered
+
+
+def _read_json_file(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _project_mcp_path(cwd: Optional[Path] = None) -> Path:
+    return (cwd or Path.cwd()) / ".mcp.json"
+
+
+def _ica_mcp_paths(ica_home: Optional[Path]) -> list[Path]:
+    if not ica_home:
+        return []
+    return [ica_home / "mcp-servers.json", ica_home / "mcp.json"]
+
+
+@dataclass(frozen=True)
+class LoadedServers:
+    servers: dict[str, dict[str, Any]]
+    sources: list[str]
+    server_sources: dict[str, str]
+    blocked_servers: dict[str, str]
+    project_root: Optional[str] = None
+    project_mcp_sha256: Optional[str] = None
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name) in ("1", "true", "TRUE", "yes", "YES", "on", "ON")
+
+
+def trust_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    if os.environ.get("ICA_MCP_TRUST_PATH"):
+        return Path(os.environ["ICA_MCP_TRUST_PATH"]).expanduser()
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-trust.json"
+
+
+def load_trust_store(*, script_file: Optional[str] = None) -> dict:
+    path = trust_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "projects": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "projects": {}}
+        if not isinstance(data.get("projects"), dict):
+            return {"version": 1, "projects": {}}
+        return data
+    except Exception:
+        return {"version": 1, "projects": {}}
+
+
+def save_trust_store(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = trust_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store trust state (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def project_mcp_sha256(project_root: Path) -> Optional[str]:
+    p = project_root / ".mcp.json"
+    if not p.exists():
+        return None
+    try:
+        raw = p.read_bytes()
+        return hashlib.sha256(raw).hexdigest()
+    except Exception:
+        return None
+
+
+def get_project_trust_status(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    current_hash = project_mcp_sha256(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    entry = (data.get("projects") or {}).get(root)
+
+    if not entry:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project is not trusted for strict project stdio execution.",
+            "current_mcp_sha256": current_hash,
+        }
+
+    trusted_hash = entry.get("mcp_sha256")
+    if current_hash and trusted_hash and current_hash != trusted_hash:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project .mcp.json changed since trust was granted.",
+            "current_mcp_sha256": current_hash,
+            "trusted_mcp_sha256": trusted_hash,
+            "trusted_at": entry.get("trusted_at"),
+        }
+
+    return {
+        "project": root,
+        "trusted": True,
+        "reason": "Trusted.",
+        "current_mcp_sha256": current_hash,
+        "trusted_mcp_sha256": trusted_hash,
+        "trusted_at": entry.get("trusted_at"),
+    }
+
+
+def trust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    projects[root] = {
+        "mcp_sha256": project_mcp_sha256(project_root.resolve()),
+        "trusted_at": int(time.time()),
+    }
+    save_trust_store(data, script_file=script_file)
+    return get_project_trust_status(project_root.resolve(), script_file=script_file)
+
+
+def untrust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> bool:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    if root in projects:
+        del projects[root]
+        save_trust_store(data, script_file=script_file)
+        return True
+    return False
+
+
+def load_servers_merged(
+    *,
+    script_file: Optional[str] = None,
+    cwd: Optional[Path] = None,
+) -> LoadedServers:
+    """
+    Load upstream server definitions.
+
+    Override modes:
+    - MCP_CONFIG (inline JSON) => only this, no merge
+    - MCP_CONFIG_PATH (path)   => only this, no merge
+
+    Default merge:
+    - project .mcp.json
+    - ICA_HOME mcp-servers.json/mcp.json
+    - (fallback) ~/.claude.json if neither exists
+
+    Precedence default: project overrides ICA_HOME.
+    Set ICA_MCP_CONFIG_PREFER_HOME=1 to flip.
+    """
+    sources: list[str] = []
+    server_sources: dict[str, str] = {}
+    blocked_servers: dict[str, str] = {}
+    current_cwd = (cwd or Path.cwd()).resolve()
+
+    # Inline JSON override
+    if env_config := os.environ.get("MCP_CONFIG"):
+        cfg = json.loads(env_config)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=["env:MCP_CONFIG"],
+            server_sources={k: "env" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    # File override
+    if env_path := os.environ.get("MCP_CONFIG_PATH"):
+        p = Path(env_path).expanduser()
+        cfg = _read_json_file(p)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=[f"file:{str(p)}"],
+            server_sources={k: "env_file" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    merged: dict[str, dict[str, Any]] = {}
+
+    ica_home = get_ica_home(script_file=script_file)
+    project_path = _project_mcp_path(cwd=cwd)
+    home_paths = _ica_mcp_paths(ica_home)
+
+    prefer_home = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME") in ("1", "true", "TRUE", "yes", "YES")
+
+    # Load layers (if present)
+    project_servers: dict[str, dict[str, Any]] = {}
+    home_servers: dict[str, dict[str, Any]] = {}
+
+    if project_path.exists():
+        project_servers = _normalize_servers(_read_json_file(project_path))
+        sources.append(f"file:{str(project_path)}")
+
+    for hp in home_paths:
+        if hp.exists():
+            home_servers = _normalize_servers(_read_json_file(hp))
+            sources.append(f"file:{str(hp)}")
+            break
+
+    # Fallback (compat only) if nothing else exists
+    if not project_servers and not home_servers:
+        claude = Path.home() / ".claude.json"
+        if claude.exists():
+            home_servers = _normalize_servers(_read_json_file(claude))
+            sources.append(f"file:{str(claude)}")
+
+    if prefer_home:
+        merge_layers = [("project", project_servers), ("home", home_servers)]
+    else:
+        merge_layers = [("home", home_servers), ("project", project_servers)]
+
+    for src_name, layer in merge_layers:
+        for name, cfg in layer.items():
+            merged[name] = cfg
+            server_sources[name] = src_name
+
+    strict_trust = _env_truthy("ICA_MCP_STRICT_TRUST")
+    allow_project_stdio = _env_truthy("ICA_MCP_ALLOW_PROJECT_STDIO")
+    project_root_path = project_path.parent.resolve()
+    project_hash = project_mcp_sha256(project_root_path)
+
+    if strict_trust and project_servers:
+        trusted_status = get_project_trust_status(project_root_path, script_file=script_file)
+        project_trusted = allow_project_stdio or bool(trusted_status.get("trusted"))
+
+        filtered: dict[str, dict[str, Any]] = {}
+        for name, cfg in merged.items():
+            if server_sources.get(name) == "project" and "command" in cfg and not project_trusted:
+                reason = trusted_status.get("reason") or "Project stdio server is not trusted."
+                blocked_servers[name] = reason
+                continue
+            filtered[name] = cfg
+        merged = filtered
+
+    return LoadedServers(
+        servers=expand_env_placeholders(merged),
+        sources=sources,
+        server_sources=server_sources,
+        blocked_servers=blocked_servers,
+        project_root=str(project_root_path),
+        project_mcp_sha256=project_hash,
+    )
+
+
+# =============================================================================
+# Token Store
+# =============================================================================
+
+def tokens_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-tokens.json"
+
+
+def load_tokens(*, script_file: Optional[str] = None) -> dict:
+    path = tokens_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "servers": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "servers": {}}
+        if "servers" not in data or not isinstance(data.get("servers"), dict):
+            return {"version": 1, "servers": {}}
+        return data
+    except Exception:
+        return {"version": 1, "servers": {}}
+
+
+def save_tokens(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = tokens_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def get_token_entry(server_name: str, *, script_file: Optional[str] = None) -> Optional[dict]:
+    data = load_tokens(script_file=script_file)
+    return data.get("servers", {}).get(server_name)
+
+
+def set_token_entry(server_name: str, entry: dict, *, script_file: Optional[str] = None) -> None:
+    data = load_tokens(script_file=script_file)
+    data.setdefault("servers", {})[server_name] = entry
+    save_tokens(data, script_file=script_file)
+
+
+def delete_token_entry(server_name: str, *, script_file: Optional[str] = None) -> bool:
+    data = load_tokens(script_file=script_file)
+    servers = data.setdefault("servers", {})
+    if server_name in servers:
+        del servers[server_name]
+        save_tokens(data, script_file=script_file)
+        return True
+    return False
+
+
+def token_is_expired(entry: dict, skew_seconds: int = 30) -> bool:
+    expires_at = entry.get("expires_at")
+    if not expires_at:
+        return False
+    try:
+        return time.time() >= float(expires_at) - skew_seconds
+    except Exception:
+        return False
+
+
+# =============================================================================
+# HTTP Helpers
+# =============================================================================
+
+def _http_json_get(url: str, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _http_form_post(url: str, data: dict, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    encoded = urllib.parse.urlencode({k: v for k, v in data.items() if v is not None}).encode("utf-8")
+    hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
+    req = urllib.request.Request(url, data=encoded, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return bool(ip.is_loopback)
+    except ValueError:
+        return False
+
+
+def _validate_secure_url(url: str, *, field: str, allow_http_loopback: bool = False) -> None:
+    parsed = urllib.parse.urlparse(str(url))
+    scheme = (parsed.scheme or "").lower()
+    host = parsed.hostname
+
+    if scheme == "https":
+        return
+    if allow_http_loopback and scheme == "http" and _is_loopback_host(host):
+        return
+    raise ValueError(
+        f"{field} must use https (or http only for localhost/loopback during local development)."
+    )
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)[:96]
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# =============================================================================
+# OAuth
+# =============================================================================
+
+def resolve_oauth_config(server_cfg: dict) -> Optional[dict]:
+    oauth = server_cfg.get("oauth")
+    if not oauth or not isinstance(oauth, dict):
+        return None
+    return oauth
+
+
+def resolve_oauth_endpoints(oauth: dict) -> dict:
+    typ = str(oauth.get("type") or "pkce").lower()
+    if typ.startswith("oidc"):
+        issuer = oauth.get("issuer")
+        if not issuer:
+            raise ValueError("oauth.issuer is required for OIDC flows.")
+        _validate_secure_url(str(issuer), field="oauth.issuer", allow_http_loopback=True)
+        well_known = str(issuer).rstrip("/") + "/.well-known/openid-configuration"
+        cfg = _http_json_get(well_known, timeout=int(oauth.get("token_timeout", 30)))
+        return {
+            "authorization_url": cfg.get("authorization_endpoint"),
+            "token_url": cfg.get("token_endpoint"),
+            "device_authorization_url": cfg.get("device_authorization_endpoint"),
+        }
+    return {
+        "authorization_url": oauth.get("authorization_url"),
+        "token_url": oauth.get("token_url"),
+        "device_authorization_url": oauth.get("device_authorization_url"),
+    }
+
+
+class _OAuthRedirectHandler(BaseHTTPRequestHandler):
+    _event: threading.Event
+    _state: str
+    _result: dict
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        qs = urllib.parse.parse_qs(parsed.query)
+        code = (qs.get("code") or [None])[0]
+        state = (qs.get("state") or [None])[0]
+        err = (qs.get("error") or [None])[0]
+        desc = (qs.get("error_description") or [None])[0]
+
+        ok = code and state == self._state and not err
+        if ok:
+            self._result.update({"code": code, "state": state})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication complete. You can close this tab.\n")
+        else:
+            self._result.update({"error": err or "invalid_redirect", "error_description": desc, "state": state})
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication failed. Return to the terminal.\n")
+
+        self._event.set()
+
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+
+async def oauth_auth_pkce(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    flow_override: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    auth_url = endpoints.get("authorization_url")
+    token_url = endpoints.get("token_url")
+    if not auth_url or not token_url:
+        raise ValueError("OAuth PKCE requires authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(auth_url), field="oauth.authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    redirect_uri = oauth.get("redirect_uri") or "http://127.0.0.1:8765/callback"
+    parsed = urllib.parse.urlparse(str(redirect_uri))
+    if parsed.scheme not in ("http",):
+        raise ValueError("oauth.redirect_uri must be an http:// localhost URL.")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8765
+    if not _is_loopback_host(host):
+        raise ValueError("oauth.redirect_uri host must be localhost or a loopback IP.")
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    extra_auth_params = oauth.get("extra_auth_params") or {}
+    if not isinstance(extra_auth_params, dict):
+        raise ValueError("oauth.extra_auth_params must be an object.")
+
+    params = {
+        "response_type": "code",
+        "client_id": str(client_id),
+        "redirect_uri": str(redirect_uri),
+        "scope": " ".join([str(s) for s in scopes]),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        **{str(k): str(v) for k, v in extra_auth_params.items()},
+    }
+    url = str(auth_url) + ("&" if "?" in str(auth_url) else "?") + urllib.parse.urlencode(params)
+
+    event = threading.Event()
+    result: dict[str, Any] = {}
+
+    def handler_factory(*_args, **_kwargs):
+        h = _OAuthRedirectHandler(*_args, **_kwargs)
+        h._event = event
+        h._state = state
+        h._result = result
+        return h
+
+    httpd = TCPServer((host, port), handler_factory)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        try:
+            import webbrowser
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+        if not event.wait(timeout=int(oauth.get("timeout", 300))):
+            raise TimeoutError("Timed out waiting for OAuth redirect.")
+
+        if "code" not in result:
+            raise ValueError(
+                f"OAuth redirect error: {result.get('error')} {result.get('error_description') or ''}".strip()
+            )
+
+        code = result["code"]
+
+        extra_token_params = oauth.get("extra_token_params") or {}
+        if not isinstance(extra_token_params, dict):
+            raise ValueError("oauth.extra_token_params must be an object.")
+
+        token_req = {
+            "grant_type": "authorization_code",
+            "client_id": str(client_id),
+            "code": code,
+            "redirect_uri": str(redirect_uri),
+            "code_verifier": verifier,
+            **{str(k): str(v) for k, v in extra_token_params.items()},
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+        access = token.get("access_token")
+        if not access:
+            raise ValueError("Token response missing access_token.")
+
+        expires_at = None
+        try:
+            if token.get("expires_in") is not None:
+                expires_at = int(time.time()) + int(token["expires_in"])
+        except Exception:
+            expires_at = None
+
+        entry = {
+            "access_token": access,
+            "refresh_token": token.get("refresh_token"),
+            "token_type": token.get("token_type") or "Bearer",
+            "scope": token.get("scope"),
+            "expires_at": expires_at,
+            "obtained_at": int(time.time()),
+        }
+        set_token_entry(server_name, entry, script_file=script_file)
+        return {"status": "ok", "server": server_name, "auth_url": url, "saved_to": str(tokens_path(script_file=script_file) or "")}
+    finally:
+        try:
+            httpd.shutdown()
+            httpd.server_close()
+        except Exception:
+            pass
+
+
+async def oauth_auth_device_code(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    device_url = endpoints.get("device_authorization_url")
+    token_url = endpoints.get("token_url")
+    if not device_url or not token_url:
+        raise ValueError("OAuth device code requires device_authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(device_url), field="oauth.device_authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    req = {"client_id": str(client_id), "scope": " ".join([str(s) for s in scopes])}
+    device = _http_form_post(str(device_url), req, timeout=int(oauth.get("token_timeout", 30)))
+    device_code = device.get("device_code")
+    user_code = device.get("user_code")
+    verify_uri = device.get("verification_uri") or device.get("verification_uri_complete")
+    interval = int(device.get("interval") or 5)
+    expires_in = int(device.get("expires_in") or 600)
+
+    if not device_code or not user_code or not verify_uri:
+        raise ValueError("Device code response missing required fields.")
+
+    instructions = {
+        "verification_uri": device.get("verification_uri"),
+        "verification_uri_complete": device.get("verification_uri_complete"),
+        "user_code": user_code,
+        "expires_in": expires_in,
+        "interval": interval,
+    }
+
+    deadline = int(time.time()) + expires_in
+    while int(time.time()) < deadline:
+        token_req = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": str(client_id),
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+        if token.get("access_token"):
+            access = token["access_token"]
+            expires_at = None
+            try:
+                if token.get("expires_in") is not None:
+                    expires_at = int(time.time()) + int(token["expires_in"])
+            except Exception:
+                expires_at = None
+            entry = {
+                "access_token": access,
+                "refresh_token": token.get("refresh_token"),
+                "token_type": token.get("token_type") or "Bearer",
+                "scope": token.get("scope"),
+                "expires_at": expires_at,
+                "obtained_at": int(time.time()),
+            }
+            set_token_entry(server_name, entry, script_file=script_file)
+            return {
+                "status": "ok",
+                "server": server_name,
+                "saved_to": str(tokens_path(script_file=script_file) or ""),
+                "device": instructions,
+            }
+
+        err = token.get("error")
+        if err == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if err == "slow_down":
+            interval += 2
+            time.sleep(interval)
+            continue
+        raise ValueError(f"Device code auth failed: {err or 'unknown_error'}")
+
+    raise TimeoutError("Device code flow timed out.")
+
+
+async def oauth_auth_client_credentials(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        raise ValueError("client_credentials flow requires oauth.token_url (or OIDC issuer providing token_endpoint).")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        raise ValueError("client_credentials flow requires oauth.client_id and oauth.client_secret.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        raise ValueError("oauth.extra_token_params must be an object.")
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+    access = token.get("access_token")
+    if not access:
+        raise ValueError("Token response missing access_token.")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return {"status": "ok", "server": server_name, "saved_to": str(tokens_path(script_file=script_file) or "")}
+
+
+def _mint_client_credentials_token(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    """
+    Synchronous client-credentials mint, used for automatic refresh during header injection.
+    """
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return None
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        return None
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        return None
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        return None
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        return None
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return None
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+def oauth_maybe_refresh(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    entry = get_token_entry(server_name, script_file=script_file)
+    if not entry or not isinstance(entry, dict):
+        return None
+
+    if not token_is_expired(entry):
+        return entry.get("access_token")
+
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return entry.get("access_token")
+
+    # If client credentials, mint again (no refresh token needed).
+    if str(oauth.get("type") or "").lower() == "client_credentials":
+        minted = _mint_client_credentials_token(server_name, server_cfg, script_file=script_file)
+        return minted or entry.get("access_token")
+
+    refresh = entry.get("refresh_token")
+    if not refresh:
+        return entry.get("access_token")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    client_id = oauth.get("client_id")
+    if not token_url or not client_id:
+        return entry.get("access_token")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    token_req = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": str(client_id),
+    }
+    if oauth.get("client_secret"):
+        token_req["client_secret"] = str(oauth["client_secret"])
+
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return entry.get("access_token")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry["access_token"] = access
+    if token.get("refresh_token"):
+        entry["refresh_token"] = token.get("refresh_token")
+    entry["token_type"] = token.get("token_type") or entry.get("token_type") or "Bearer"
+    entry["scope"] = token.get("scope") or entry.get("scope")
+    entry["expires_at"] = expires_at
+    entry["obtained_at"] = int(time.time())
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+# =============================================================================
+# Transport / Session (Client)
+# =============================================================================
+
+def detect_transport(config: dict) -> str:
+    if explicit_type := config.get("type"):
+        type_map = {
+            "stdio": "stdio",
+            "sse": "sse",
+            "http": "streamable_http",
+            "streamable_http": "streamable_http",
+            "streamable-http": "streamable_http",
+        }
+        return type_map.get(str(explicit_type).lower(), str(explicit_type).lower())
+
+    if "command" in config:
+        return "stdio"
+
+    if "url" in config:
+        url = str(config["url"])
+        if url.endswith("/mcp"):
+            return "streamable_http"
+        if url.endswith("/sse"):
+            return "sse"
+        return "sse"
+
+    raise ValueError("Cannot detect transport: server config must have 'command' or 'url'.")
+
+
+def build_auth_headers(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    force_refresh: bool = False,
+) -> dict:
+    headers = dict(server_cfg.get("headers") or {})
+
+    # Explicit header always wins.
+    if "Authorization" in headers:
+        return headers
+
+    if "api_key" in server_cfg:
+        headers["Authorization"] = f"Bearer {server_cfg['api_key']}"
+        return headers
+
+    tok = oauth_maybe_refresh(server_name, server_cfg, script_file=script_file)
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    return headers
+
+
+@asynccontextmanager
+async def create_session(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None):
+    transport = detect_transport(server_cfg)
+
+    try:
+        from mcp import ClientSession, StdioServerParameters  # type: ignore
+    except Exception:
+        missing_dep("mcp")
+
+    if transport == "stdio":
+        from mcp.client.stdio import stdio_client  # type: ignore
+
+        env = {**os.environ}
+        if cfg_env := server_cfg.get("env"):
+            if isinstance(cfg_env, dict):
+                env.update({str(k): str(v) for k, v in cfg_env.items()})
+
+        params = StdioServerParameters(
+            command=server_cfg["command"],
+            args=server_cfg.get("args", []),
+            env=env,
+            cwd=server_cfg.get("cwd"),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "sse":
+        from mcp.client.sse import sse_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with sse_client(url, headers=headers, timeout=timeout) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "streamable_http":
+        from mcp.client.streamable_http import streamablehttp_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with streamablehttp_client(url, headers=headers, timeout=timeout) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise ValueError(f"Unsupported transport: {transport}")

--- a/src/skills/mcp-proxy/scripts/_internal/ica_mcp_core.py
+++ b/src/skills/mcp-proxy/scripts/_internal/ica_mcp_core.py
@@ -1,0 +1,1139 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Core
+
+Shared building blocks for:
+- mcp-client (CLI)
+- mcp-proxy (local stdio MCP server that mirrors upstream tools)
+
+Responsibilities:
+- Load/merge MCP server definitions from:
+  - MCP_CONFIG (inline JSON) / MCP_CONFIG_PATH (single file override)
+  - project .mcp.json
+  - $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - ~/.claude.json fallback (compat only)
+- Expand ${ENV_VAR} placeholders
+- Token store under $ICA_HOME/mcp-tokens.json
+- OAuth flows:
+  - PKCE (explicit endpoints or OIDC discovery)
+  - Device code (explicit endpoints or OIDC discovery)
+  - Client credentials (explicit token endpoint)
+- Create MCP client sessions for stdio/sse/streamable_http
+
+This module is intentionally dependency-light (stdlib + `mcp` when used for sessions).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+import time
+import threading
+import urllib.parse
+import urllib.request
+import ipaddress
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from socketserver import TCPServer
+from typing import Any, Optional
+
+
+class DependencyError(RuntimeError):
+    pass
+
+
+def missing_dep(dep: str, extra: str = "") -> None:
+    hint = f"Missing dependency '{dep}'. Install it with: pip install {dep}"
+    if extra:
+        hint = f"{hint}. {extra}"
+    raise DependencyError(hint)
+
+
+# =============================================================================
+# ICA_HOME Resolution
+# =============================================================================
+
+def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
+    """
+    Resolve ICA_HOME (agent home directory).
+
+    Priority:
+    - ICA_HOME env var
+    - infer from installed skill layout: <ICA_HOME>/skills/<skill>/scripts/<file>.py
+    """
+    if os.environ.get("ICA_HOME"):
+        return Path(os.environ["ICA_HOME"]).expanduser()
+
+    if script_file:
+        p = Path(script_file).resolve()
+        # .../skills/<skill>/scripts/<file>
+        try:
+            if p.parents[2].name == "skills":
+                candidate = p.parents[3]
+                # Guard: avoid treating repo layout (src/skills/...) as ICA_HOME.
+                # Installed ICA homes include VERSION at the root.
+                if (candidate / "VERSION").exists():
+                    return candidate
+        except Exception:
+            return None
+
+    return None
+
+
+# =============================================================================
+# Config Loading / Merging
+# =============================================================================
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
+
+
+def expand_env_placeholders(value: Any) -> Any:
+    """
+    Best-effort `${VAR}` expansion for config values.
+    - Only expands when VAR is present in the process environment.
+    - Leaves unknown placeholders unchanged (so configs remain portable).
+    """
+    if isinstance(value, str):
+        def repl(match: re.Match) -> str:
+            name = match.group(1)
+            return os.environ.get(name, match.group(0))
+
+        return _ENV_VAR_PATTERN.sub(repl, value)
+
+    if isinstance(value, list):
+        return [expand_env_placeholders(v) for v in value]
+
+    if isinstance(value, dict):
+        return {k: expand_env_placeholders(v) for k, v in value.items()}
+
+    return value
+
+
+def _normalize_servers(config: dict) -> dict[str, dict[str, Any]]:
+    servers = config.get("mcpServers", config)
+    if not isinstance(servers, dict):
+        raise ValueError("Config must be an object or contain an 'mcpServers' object.")
+
+    filtered: dict[str, dict[str, Any]] = {}
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if "command" in cfg or "url" in cfg:
+            filtered[str(name)] = cfg
+    return filtered
+
+
+def _read_json_file(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _project_mcp_path(cwd: Optional[Path] = None) -> Path:
+    return (cwd or Path.cwd()) / ".mcp.json"
+
+
+def _ica_mcp_paths(ica_home: Optional[Path]) -> list[Path]:
+    if not ica_home:
+        return []
+    return [ica_home / "mcp-servers.json", ica_home / "mcp.json"]
+
+
+@dataclass(frozen=True)
+class LoadedServers:
+    servers: dict[str, dict[str, Any]]
+    sources: list[str]
+    server_sources: dict[str, str]
+    blocked_servers: dict[str, str]
+    project_root: Optional[str] = None
+    project_mcp_sha256: Optional[str] = None
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name) in ("1", "true", "TRUE", "yes", "YES", "on", "ON")
+
+
+def trust_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    if os.environ.get("ICA_MCP_TRUST_PATH"):
+        return Path(os.environ["ICA_MCP_TRUST_PATH"]).expanduser()
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-trust.json"
+
+
+def load_trust_store(*, script_file: Optional[str] = None) -> dict:
+    path = trust_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "projects": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "projects": {}}
+        if not isinstance(data.get("projects"), dict):
+            return {"version": 1, "projects": {}}
+        return data
+    except Exception:
+        return {"version": 1, "projects": {}}
+
+
+def save_trust_store(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = trust_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store trust state (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def project_mcp_sha256(project_root: Path) -> Optional[str]:
+    p = project_root / ".mcp.json"
+    if not p.exists():
+        return None
+    try:
+        raw = p.read_bytes()
+        return hashlib.sha256(raw).hexdigest()
+    except Exception:
+        return None
+
+
+def get_project_trust_status(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    current_hash = project_mcp_sha256(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    entry = (data.get("projects") or {}).get(root)
+
+    if not entry:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project is not trusted for strict project stdio execution.",
+            "current_mcp_sha256": current_hash,
+        }
+
+    trusted_hash = entry.get("mcp_sha256")
+    if current_hash and trusted_hash and current_hash != trusted_hash:
+        return {
+            "project": root,
+            "trusted": False,
+            "reason": "Project .mcp.json changed since trust was granted.",
+            "current_mcp_sha256": current_hash,
+            "trusted_mcp_sha256": trusted_hash,
+            "trusted_at": entry.get("trusted_at"),
+        }
+
+    return {
+        "project": root,
+        "trusted": True,
+        "reason": "Trusted.",
+        "current_mcp_sha256": current_hash,
+        "trusted_mcp_sha256": trusted_hash,
+        "trusted_at": entry.get("trusted_at"),
+    }
+
+
+def trust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> dict[str, Any]:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    projects[root] = {
+        "mcp_sha256": project_mcp_sha256(project_root.resolve()),
+        "trusted_at": int(time.time()),
+    }
+    save_trust_store(data, script_file=script_file)
+    return get_project_trust_status(project_root.resolve(), script_file=script_file)
+
+
+def untrust_project(
+    project_root: Path,
+    *,
+    script_file: Optional[str] = None,
+) -> bool:
+    root = str(project_root.resolve())
+    data = load_trust_store(script_file=script_file)
+    projects = data.setdefault("projects", {})
+    if root in projects:
+        del projects[root]
+        save_trust_store(data, script_file=script_file)
+        return True
+    return False
+
+
+def load_servers_merged(
+    *,
+    script_file: Optional[str] = None,
+    cwd: Optional[Path] = None,
+) -> LoadedServers:
+    """
+    Load upstream server definitions.
+
+    Override modes:
+    - MCP_CONFIG (inline JSON) => only this, no merge
+    - MCP_CONFIG_PATH (path)   => only this, no merge
+
+    Default merge:
+    - project .mcp.json
+    - ICA_HOME mcp-servers.json/mcp.json
+    - (fallback) ~/.claude.json if neither exists
+
+    Precedence default: project overrides ICA_HOME.
+    Set ICA_MCP_CONFIG_PREFER_HOME=1 to flip.
+    """
+    sources: list[str] = []
+    server_sources: dict[str, str] = {}
+    blocked_servers: dict[str, str] = {}
+    current_cwd = (cwd or Path.cwd()).resolve()
+
+    # Inline JSON override
+    if env_config := os.environ.get("MCP_CONFIG"):
+        cfg = json.loads(env_config)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=["env:MCP_CONFIG"],
+            server_sources={k: "env" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    # File override
+    if env_path := os.environ.get("MCP_CONFIG_PATH"):
+        p = Path(env_path).expanduser()
+        cfg = _read_json_file(p)
+        servers = _normalize_servers(cfg)
+        return LoadedServers(
+            servers=expand_env_placeholders(servers),
+            sources=[f"file:{str(p)}"],
+            server_sources={k: "env_file" for k in servers.keys()},
+            blocked_servers={},
+            project_root=str(current_cwd),
+            project_mcp_sha256=project_mcp_sha256(current_cwd),
+        )
+
+    merged: dict[str, dict[str, Any]] = {}
+
+    ica_home = get_ica_home(script_file=script_file)
+    project_path = _project_mcp_path(cwd=cwd)
+    home_paths = _ica_mcp_paths(ica_home)
+
+    prefer_home = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME") in ("1", "true", "TRUE", "yes", "YES")
+
+    # Load layers (if present)
+    project_servers: dict[str, dict[str, Any]] = {}
+    home_servers: dict[str, dict[str, Any]] = {}
+
+    if project_path.exists():
+        project_servers = _normalize_servers(_read_json_file(project_path))
+        sources.append(f"file:{str(project_path)}")
+
+    for hp in home_paths:
+        if hp.exists():
+            home_servers = _normalize_servers(_read_json_file(hp))
+            sources.append(f"file:{str(hp)}")
+            break
+
+    # Fallback (compat only) if nothing else exists
+    if not project_servers and not home_servers:
+        claude = Path.home() / ".claude.json"
+        if claude.exists():
+            home_servers = _normalize_servers(_read_json_file(claude))
+            sources.append(f"file:{str(claude)}")
+
+    if prefer_home:
+        merge_layers = [("project", project_servers), ("home", home_servers)]
+    else:
+        merge_layers = [("home", home_servers), ("project", project_servers)]
+
+    for src_name, layer in merge_layers:
+        for name, cfg in layer.items():
+            merged[name] = cfg
+            server_sources[name] = src_name
+
+    strict_trust = _env_truthy("ICA_MCP_STRICT_TRUST")
+    allow_project_stdio = _env_truthy("ICA_MCP_ALLOW_PROJECT_STDIO")
+    project_root_path = project_path.parent.resolve()
+    project_hash = project_mcp_sha256(project_root_path)
+
+    if strict_trust and project_servers:
+        trusted_status = get_project_trust_status(project_root_path, script_file=script_file)
+        project_trusted = allow_project_stdio or bool(trusted_status.get("trusted"))
+
+        filtered: dict[str, dict[str, Any]] = {}
+        for name, cfg in merged.items():
+            if server_sources.get(name) == "project" and "command" in cfg and not project_trusted:
+                reason = trusted_status.get("reason") or "Project stdio server is not trusted."
+                blocked_servers[name] = reason
+                continue
+            filtered[name] = cfg
+        merged = filtered
+
+    return LoadedServers(
+        servers=expand_env_placeholders(merged),
+        sources=sources,
+        server_sources=server_sources,
+        blocked_servers=blocked_servers,
+        project_root=str(project_root_path),
+        project_mcp_sha256=project_hash,
+    )
+
+
+# =============================================================================
+# Token Store
+# =============================================================================
+
+def tokens_path(*, script_file: Optional[str] = None) -> Optional[Path]:
+    ica_home = get_ica_home(script_file=script_file)
+    if not ica_home:
+        return None
+    return ica_home / "mcp-tokens.json"
+
+
+def load_tokens(*, script_file: Optional[str] = None) -> dict:
+    path = tokens_path(script_file=script_file)
+    if not path or not path.exists():
+        return {"version": 1, "servers": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"version": 1, "servers": {}}
+        if "servers" not in data or not isinstance(data.get("servers"), dict):
+            return {"version": 1, "servers": {}}
+        return data
+    except Exception:
+        return {"version": 1, "servers": {}}
+
+
+def save_tokens(data: dict, *, script_file: Optional[str] = None) -> None:
+    path = tokens_path(script_file=script_file)
+    if not path:
+        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+        raise
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
+def get_token_entry(server_name: str, *, script_file: Optional[str] = None) -> Optional[dict]:
+    data = load_tokens(script_file=script_file)
+    return data.get("servers", {}).get(server_name)
+
+
+def set_token_entry(server_name: str, entry: dict, *, script_file: Optional[str] = None) -> None:
+    data = load_tokens(script_file=script_file)
+    data.setdefault("servers", {})[server_name] = entry
+    save_tokens(data, script_file=script_file)
+
+
+def delete_token_entry(server_name: str, *, script_file: Optional[str] = None) -> bool:
+    data = load_tokens(script_file=script_file)
+    servers = data.setdefault("servers", {})
+    if server_name in servers:
+        del servers[server_name]
+        save_tokens(data, script_file=script_file)
+        return True
+    return False
+
+
+def token_is_expired(entry: dict, skew_seconds: int = 30) -> bool:
+    expires_at = entry.get("expires_at")
+    if not expires_at:
+        return False
+    try:
+        return time.time() >= float(expires_at) - skew_seconds
+    except Exception:
+        return False
+
+
+# =============================================================================
+# HTTP Helpers
+# =============================================================================
+
+def _http_json_get(url: str, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _http_form_post(url: str, data: dict, headers: Optional[dict] = None, timeout: int = 30) -> dict:
+    encoded = urllib.parse.urlencode({k: v for k, v in data.items() if v is not None}).encode("utf-8")
+    hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
+    req = urllib.request.Request(url, data=encoded, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", errors="replace")
+            return json.loads(body)
+        except Exception:
+            raise
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return bool(ip.is_loopback)
+    except ValueError:
+        return False
+
+
+def _validate_secure_url(url: str, *, field: str, allow_http_loopback: bool = False) -> None:
+    parsed = urllib.parse.urlparse(str(url))
+    scheme = (parsed.scheme or "").lower()
+    host = parsed.hostname
+
+    if scheme == "https":
+        return
+    if allow_http_loopback and scheme == "http" and _is_loopback_host(host):
+        return
+    raise ValueError(
+        f"{field} must use https (or http only for localhost/loopback during local development)."
+    )
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)[:96]
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# =============================================================================
+# OAuth
+# =============================================================================
+
+def resolve_oauth_config(server_cfg: dict) -> Optional[dict]:
+    oauth = server_cfg.get("oauth")
+    if not oauth or not isinstance(oauth, dict):
+        return None
+    return oauth
+
+
+def resolve_oauth_endpoints(oauth: dict) -> dict:
+    typ = str(oauth.get("type") or "pkce").lower()
+    if typ.startswith("oidc"):
+        issuer = oauth.get("issuer")
+        if not issuer:
+            raise ValueError("oauth.issuer is required for OIDC flows.")
+        _validate_secure_url(str(issuer), field="oauth.issuer", allow_http_loopback=True)
+        well_known = str(issuer).rstrip("/") + "/.well-known/openid-configuration"
+        cfg = _http_json_get(well_known, timeout=int(oauth.get("token_timeout", 30)))
+        return {
+            "authorization_url": cfg.get("authorization_endpoint"),
+            "token_url": cfg.get("token_endpoint"),
+            "device_authorization_url": cfg.get("device_authorization_endpoint"),
+        }
+    return {
+        "authorization_url": oauth.get("authorization_url"),
+        "token_url": oauth.get("token_url"),
+        "device_authorization_url": oauth.get("device_authorization_url"),
+    }
+
+
+class _OAuthRedirectHandler(BaseHTTPRequestHandler):
+    _event: threading.Event
+    _state: str
+    _result: dict
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        qs = urllib.parse.parse_qs(parsed.query)
+        code = (qs.get("code") or [None])[0]
+        state = (qs.get("state") or [None])[0]
+        err = (qs.get("error") or [None])[0]
+        desc = (qs.get("error_description") or [None])[0]
+
+        ok = code and state == self._state and not err
+        if ok:
+            self._result.update({"code": code, "state": state})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication complete. You can close this tab.\n")
+        else:
+            self._result.update({"error": err or "invalid_redirect", "error_description": desc, "state": state})
+            self.send_response(400)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"Authentication failed. Return to the terminal.\n")
+
+        self._event.set()
+
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+
+async def oauth_auth_pkce(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    flow_override: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    auth_url = endpoints.get("authorization_url")
+    token_url = endpoints.get("token_url")
+    if not auth_url or not token_url:
+        raise ValueError("OAuth PKCE requires authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(auth_url), field="oauth.authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    redirect_uri = oauth.get("redirect_uri") or "http://127.0.0.1:8765/callback"
+    parsed = urllib.parse.urlparse(str(redirect_uri))
+    if parsed.scheme not in ("http",):
+        raise ValueError("oauth.redirect_uri must be an http:// localhost URL.")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8765
+    if not _is_loopback_host(host):
+        raise ValueError("oauth.redirect_uri host must be localhost or a loopback IP.")
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    extra_auth_params = oauth.get("extra_auth_params") or {}
+    if not isinstance(extra_auth_params, dict):
+        raise ValueError("oauth.extra_auth_params must be an object.")
+
+    params = {
+        "response_type": "code",
+        "client_id": str(client_id),
+        "redirect_uri": str(redirect_uri),
+        "scope": " ".join([str(s) for s in scopes]),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        **{str(k): str(v) for k, v in extra_auth_params.items()},
+    }
+    url = str(auth_url) + ("&" if "?" in str(auth_url) else "?") + urllib.parse.urlencode(params)
+
+    event = threading.Event()
+    result: dict[str, Any] = {}
+
+    def handler_factory(*_args, **_kwargs):
+        h = _OAuthRedirectHandler(*_args, **_kwargs)
+        h._event = event
+        h._state = state
+        h._result = result
+        return h
+
+    httpd = TCPServer((host, port), handler_factory)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+
+    try:
+        try:
+            import webbrowser
+            webbrowser.open(url)
+        except Exception:
+            pass
+
+        if not event.wait(timeout=int(oauth.get("timeout", 300))):
+            raise TimeoutError("Timed out waiting for OAuth redirect.")
+
+        if "code" not in result:
+            raise ValueError(
+                f"OAuth redirect error: {result.get('error')} {result.get('error_description') or ''}".strip()
+            )
+
+        code = result["code"]
+
+        extra_token_params = oauth.get("extra_token_params") or {}
+        if not isinstance(extra_token_params, dict):
+            raise ValueError("oauth.extra_token_params must be an object.")
+
+        token_req = {
+            "grant_type": "authorization_code",
+            "client_id": str(client_id),
+            "code": code,
+            "redirect_uri": str(redirect_uri),
+            "code_verifier": verifier,
+            **{str(k): str(v) for k, v in extra_token_params.items()},
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+        access = token.get("access_token")
+        if not access:
+            raise ValueError("Token response missing access_token.")
+
+        expires_at = None
+        try:
+            if token.get("expires_in") is not None:
+                expires_at = int(time.time()) + int(token["expires_in"])
+        except Exception:
+            expires_at = None
+
+        entry = {
+            "access_token": access,
+            "refresh_token": token.get("refresh_token"),
+            "token_type": token.get("token_type") or "Bearer",
+            "scope": token.get("scope"),
+            "expires_at": expires_at,
+            "obtained_at": int(time.time()),
+        }
+        set_token_entry(server_name, entry, script_file=script_file)
+        return {"status": "ok", "server": server_name, "auth_url": url, "saved_to": str(tokens_path(script_file=script_file) or "")}
+    finally:
+        try:
+            httpd.shutdown()
+            httpd.server_close()
+        except Exception:
+            pass
+
+
+async def oauth_auth_device_code(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    device_url = endpoints.get("device_authorization_url")
+    token_url = endpoints.get("token_url")
+    if not device_url or not token_url:
+        raise ValueError("OAuth device code requires device_authorization_url and token_url (or OIDC issuer).")
+    _validate_secure_url(str(device_url), field="oauth.device_authorization_url", allow_http_loopback=True)
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    if not client_id:
+        raise ValueError("oauth.client_id is required.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    req = {"client_id": str(client_id), "scope": " ".join([str(s) for s in scopes])}
+    device = _http_form_post(str(device_url), req, timeout=int(oauth.get("token_timeout", 30)))
+    device_code = device.get("device_code")
+    user_code = device.get("user_code")
+    verify_uri = device.get("verification_uri") or device.get("verification_uri_complete")
+    interval = int(device.get("interval") or 5)
+    expires_in = int(device.get("expires_in") or 600)
+
+    if not device_code or not user_code or not verify_uri:
+        raise ValueError("Device code response missing required fields.")
+
+    instructions = {
+        "verification_uri": device.get("verification_uri"),
+        "verification_uri_complete": device.get("verification_uri_complete"),
+        "user_code": user_code,
+        "expires_in": expires_in,
+        "interval": interval,
+    }
+
+    deadline = int(time.time()) + expires_in
+    while int(time.time()) < deadline:
+        token_req = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": str(client_id),
+        }
+        if oauth.get("client_secret"):
+            token_req["client_secret"] = str(oauth["client_secret"])
+        token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+        if token.get("access_token"):
+            access = token["access_token"]
+            expires_at = None
+            try:
+                if token.get("expires_in") is not None:
+                    expires_at = int(time.time()) + int(token["expires_in"])
+            except Exception:
+                expires_at = None
+            entry = {
+                "access_token": access,
+                "refresh_token": token.get("refresh_token"),
+                "token_type": token.get("token_type") or "Bearer",
+                "scope": token.get("scope"),
+                "expires_at": expires_at,
+                "obtained_at": int(time.time()),
+            }
+            set_token_entry(server_name, entry, script_file=script_file)
+            return {
+                "status": "ok",
+                "server": server_name,
+                "saved_to": str(tokens_path(script_file=script_file) or ""),
+                "device": instructions,
+            }
+
+        err = token.get("error")
+        if err == "authorization_pending":
+            time.sleep(interval)
+            continue
+        if err == "slow_down":
+            interval += 2
+            time.sleep(interval)
+            continue
+        raise ValueError(f"Device code auth failed: {err or 'unknown_error'}")
+
+    raise TimeoutError("Device code flow timed out.")
+
+
+async def oauth_auth_client_credentials(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+) -> dict:
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        raise ValueError("Server is missing oauth configuration.")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        raise ValueError("client_credentials flow requires oauth.token_url (or OIDC issuer providing token_endpoint).")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        raise ValueError("client_credentials flow requires oauth.client_id and oauth.client_secret.")
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        raise ValueError("oauth.scopes must be a list of strings or a space-delimited string.")
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        raise ValueError("oauth.extra_token_params must be an object.")
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+
+    access = token.get("access_token")
+    if not access:
+        raise ValueError("Token response missing access_token.")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return {"status": "ok", "server": server_name, "saved_to": str(tokens_path(script_file=script_file) or "")}
+
+
+def _mint_client_credentials_token(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    """
+    Synchronous client-credentials mint, used for automatic refresh during header injection.
+    """
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return None
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    if not token_url:
+        return None
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    client_id = oauth.get("client_id")
+    client_secret = oauth.get("client_secret")
+    if not client_id or not client_secret:
+        return None
+
+    scopes = oauth.get("scopes") or []
+    if isinstance(scopes, str):
+        scopes = scopes.split()
+    if scopes and not isinstance(scopes, list):
+        return None
+
+    extra_token_params = oauth.get("extra_token_params") or {}
+    if extra_token_params and not isinstance(extra_token_params, dict):
+        return None
+
+    token_req = {
+        "grant_type": "client_credentials",
+        "client_id": str(client_id),
+        "client_secret": str(client_secret),
+        "scope": " ".join([str(s) for s in scopes]) if scopes else None,
+        **{str(k): str(v) for k, v in (extra_token_params or {}).items()},
+    }
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return None
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry = {
+        "access_token": access,
+        "refresh_token": token.get("refresh_token"),
+        "token_type": token.get("token_type") or "Bearer",
+        "scope": token.get("scope"),
+        "expires_at": expires_at,
+        "obtained_at": int(time.time()),
+        "grant_type": "client_credentials",
+    }
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+def oauth_maybe_refresh(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None) -> Optional[str]:
+    entry = get_token_entry(server_name, script_file=script_file)
+    if not entry or not isinstance(entry, dict):
+        return None
+
+    if not token_is_expired(entry):
+        return entry.get("access_token")
+
+    oauth = resolve_oauth_config(server_cfg)
+    if not oauth:
+        return entry.get("access_token")
+
+    # If client credentials, mint again (no refresh token needed).
+    if str(oauth.get("type") or "").lower() == "client_credentials":
+        minted = _mint_client_credentials_token(server_name, server_cfg, script_file=script_file)
+        return minted or entry.get("access_token")
+
+    refresh = entry.get("refresh_token")
+    if not refresh:
+        return entry.get("access_token")
+
+    endpoints = resolve_oauth_endpoints(oauth)
+    token_url = endpoints.get("token_url") or oauth.get("token_url")
+    client_id = oauth.get("client_id")
+    if not token_url or not client_id:
+        return entry.get("access_token")
+    _validate_secure_url(str(token_url), field="oauth.token_url", allow_http_loopback=True)
+
+    token_req = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh,
+        "client_id": str(client_id),
+    }
+    if oauth.get("client_secret"):
+        token_req["client_secret"] = str(oauth["client_secret"])
+
+    token = _http_form_post(str(token_url), token_req, timeout=int(oauth.get("token_timeout", 30)))
+    access = token.get("access_token")
+    if not access:
+        return entry.get("access_token")
+
+    expires_at = None
+    try:
+        if token.get("expires_in") is not None:
+            expires_at = int(time.time()) + int(token["expires_in"])
+    except Exception:
+        expires_at = None
+
+    entry["access_token"] = access
+    if token.get("refresh_token"):
+        entry["refresh_token"] = token.get("refresh_token")
+    entry["token_type"] = token.get("token_type") or entry.get("token_type") or "Bearer"
+    entry["scope"] = token.get("scope") or entry.get("scope")
+    entry["expires_at"] = expires_at
+    entry["obtained_at"] = int(time.time())
+    set_token_entry(server_name, entry, script_file=script_file)
+    return access
+
+
+# =============================================================================
+# Transport / Session (Client)
+# =============================================================================
+
+def detect_transport(config: dict) -> str:
+    if explicit_type := config.get("type"):
+        type_map = {
+            "stdio": "stdio",
+            "sse": "sse",
+            "http": "streamable_http",
+            "streamable_http": "streamable_http",
+            "streamable-http": "streamable_http",
+        }
+        return type_map.get(str(explicit_type).lower(), str(explicit_type).lower())
+
+    if "command" in config:
+        return "stdio"
+
+    if "url" in config:
+        url = str(config["url"])
+        if url.endswith("/mcp"):
+            return "streamable_http"
+        if url.endswith("/sse"):
+            return "sse"
+        return "sse"
+
+    raise ValueError("Cannot detect transport: server config must have 'command' or 'url'.")
+
+
+def build_auth_headers(
+    server_name: str,
+    server_cfg: dict,
+    *,
+    script_file: Optional[str] = None,
+    force_refresh: bool = False,
+) -> dict:
+    headers = dict(server_cfg.get("headers") or {})
+
+    # Explicit header always wins.
+    if "Authorization" in headers:
+        return headers
+
+    if "api_key" in server_cfg:
+        headers["Authorization"] = f"Bearer {server_cfg['api_key']}"
+        return headers
+
+    tok = oauth_maybe_refresh(server_name, server_cfg, script_file=script_file)
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    return headers
+
+
+@asynccontextmanager
+async def create_session(server_name: str, server_cfg: dict, *, script_file: Optional[str] = None):
+    transport = detect_transport(server_cfg)
+
+    try:
+        from mcp import ClientSession, StdioServerParameters  # type: ignore
+    except Exception:
+        missing_dep("mcp")
+
+    if transport == "stdio":
+        from mcp.client.stdio import stdio_client  # type: ignore
+
+        env = {**os.environ}
+        if cfg_env := server_cfg.get("env"):
+            if isinstance(cfg_env, dict):
+                env.update({str(k): str(v) for k, v in cfg_env.items()})
+
+        params = StdioServerParameters(
+            command=server_cfg["command"],
+            args=server_cfg.get("args", []),
+            env=env,
+            cwd=server_cfg.get("cwd"),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "sse":
+        from mcp.client.sse import sse_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with sse_client(url, headers=headers, timeout=timeout) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "streamable_http":
+        from mcp.client.streamable_http import streamablehttp_client  # type: ignore
+        url = server_cfg["url"]
+        headers = build_auth_headers(server_name, server_cfg, script_file=script_file)
+        timeout = server_cfg.get("timeout", 30)
+        async with streamablehttp_client(url, headers=headers, timeout=timeout) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise ValueError(f"Unsupported transport: {transport}")

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Proxy CLI (helper)
+
+This is optional, but useful for debugging without involving an agent runtime.
+
+Commands:
+  servers
+  trust [project_path]
+  trust-status [project_path]
+  untrust [project_path]
+  mirror-status
+  token <server>
+  logout <server>
+
+Notes:
+  - Trust commands are used with ICA_MCP_STRICT_TRUST=1.
+  - `trust` stores trust in $ICA_HOME/mcp-trust.json (or ICA_MCP_TRUST_PATH).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _import_core():
+    here = Path(__file__).resolve()
+    skills_dir = here.parents[2]
+    bundled = here.parent / "_internal"
+    common = skills_dir / "mcp-common" / "scripts"
+    import sys as _sys
+
+    for candidate in (bundled, common):
+        if candidate.exists():
+            resolved = str(candidate)
+            if resolved not in _sys.path:
+                _sys.path.append(resolved)
+
+    try:
+        from ica_mcp_core import (  # type: ignore
+            delete_token_entry,
+            get_project_trust_status,
+            get_token_entry,
+            load_servers_merged,
+            token_is_expired,
+            trust_path,
+            trust_project,
+            untrust_project,
+        )
+
+        return (
+            delete_token_entry,
+            get_project_trust_status,
+            get_token_entry,
+            load_servers_merged,
+            token_is_expired,
+            trust_path,
+            trust_project,
+            untrust_project,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to import ICA MCP core. "
+            "Expected either bundled fallback at '_internal/ica_mcp_core.py' "
+            "or shared 'mcp-common/scripts/ica_mcp_core.py'."
+        ) from e
+
+
+(
+    delete_token_entry,
+    get_project_trust_status,
+    get_token_entry,
+    load_servers_merged,
+    token_is_expired,
+    trust_path,
+    trust_project,
+    untrust_project,
+) = _import_core()
+
+
+def _print(data):
+    print(json.dumps(data, indent=2, default=str))
+
+
+def _project_from_argv() -> Path:
+    if len(sys.argv) >= 3:
+        return Path(sys.argv[2]).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name) in ("1", "true", "TRUE", "yes", "YES", "on", "ON")
+
+
+async def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
+        print(__doc__.strip())
+        raise SystemExit(0)
+
+    cmd = sys.argv[1]
+
+    if cmd == "servers":
+        loaded = load_servers_merged(script_file=__file__)
+        _print(
+            {
+                "servers": sorted(loaded.servers.keys()),
+                "sources": loaded.sources,
+                "blocked_servers": getattr(loaded, "blocked_servers", {}),
+                "strict_trust": _env_truthy("ICA_MCP_STRICT_TRUST"),
+            }
+        )
+        return
+
+    if cmd == "mirror-status":
+        loaded = load_servers_merged(script_file=__file__)
+        _print(
+            {
+                "note": "Static preview only. Use proxy.mirror_status from an MCP client for runtime mirror details.",
+                "servers_configured": sorted(loaded.servers.keys()),
+                "blocked_servers": getattr(loaded, "blocked_servers", {}),
+            }
+        )
+        return
+
+    if cmd == "trust":
+        project = _project_from_argv()
+        out = trust_project(project, script_file=__file__)
+        out["trust_store"] = str(trust_path(script_file=__file__) or "")
+        _print(out)
+        return
+
+    if cmd == "trust-status":
+        project = _project_from_argv()
+        out = get_project_trust_status(project, script_file=__file__)
+        out["trust_store"] = str(trust_path(script_file=__file__) or "")
+        _print(out)
+        return
+
+    if cmd == "untrust":
+        project = _project_from_argv()
+        ok = untrust_project(project, script_file=__file__)
+        _print(
+            {
+                "project": str(project),
+                "status": "removed" if ok else "missing",
+                "trust_store": str(trust_path(script_file=__file__) or ""),
+            }
+        )
+        return
+
+    if cmd == "token":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: token <server>")
+        s = sys.argv[2]
+        entry = get_token_entry(s, script_file=__file__)
+        if not entry:
+            _print({"server": s, "status": "missing"})
+            return
+        _print(
+            {
+                "server": s,
+                "status": "present",
+                "expired": token_is_expired(entry),
+                "expires_at": entry.get("expires_at"),
+                "scope": entry.get("scope"),
+                "token_type": entry.get("token_type"),
+            }
+        )
+        return
+
+    if cmd == "logout":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: logout <server>")
+        s = sys.argv[2]
+        ok = delete_token_entry(s, script_file=__file__)
+        _print({"server": s, "status": "deleted" if ok else "missing"})
+        return
+
+    raise SystemExit(f"Unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
@@ -1,0 +1,783 @@
+#!/usr/bin/env python3
+"""
+ICA MCP Proxy Server (stdio)
+
+Implements a local MCP server that:
+- loads upstream MCP servers from .mcp.json and/or $ICA_HOME/mcp-servers.json
+- mirrors upstream tools as proxy tools: "<server>.<tool>"
+- provides stable broker tools under "proxy.*"
+- manages OAuth + token caching in $ICA_HOME/mcp-tokens.json
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import os
+import re
+import time
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _import_core():
+    # Resolve bundled fallback first, then shared mcp-common for installed setups.
+    here = Path(__file__).resolve()
+    skills_dir = here.parents[2]  # .../skills
+    bundled = here.parent / "_internal"
+    common = skills_dir / "mcp-common" / "scripts"
+    import sys
+
+    for candidate in (bundled, common):
+        if candidate.exists():
+            resolved = str(candidate)
+            if resolved not in sys.path:
+                sys.path.append(resolved)
+    try:
+        from ica_mcp_core import (  # type: ignore
+            DependencyError,
+            create_session,
+            delete_token_entry,
+            detect_transport,
+            get_token_entry,
+            load_servers_merged,
+            oauth_auth_client_credentials,
+            oauth_auth_device_code,
+            oauth_auth_pkce,
+            oauth_maybe_refresh,
+            resolve_oauth_config,
+            set_token_entry,
+            token_is_expired,
+            tokens_path,
+        )
+
+        return {
+            "DependencyError": DependencyError,
+            "create_session": create_session,
+            "delete_token_entry": delete_token_entry,
+            "detect_transport": detect_transport,
+            "get_token_entry": get_token_entry,
+            "load_servers_merged": load_servers_merged,
+            "oauth_auth_client_credentials": oauth_auth_client_credentials,
+            "oauth_auth_device_code": oauth_auth_device_code,
+            "oauth_auth_pkce": oauth_auth_pkce,
+            "oauth_maybe_refresh": oauth_maybe_refresh,
+            "resolve_oauth_config": resolve_oauth_config,
+            "set_token_entry": set_token_entry,
+            "token_is_expired": token_is_expired,
+            "tokens_path": tokens_path,
+        }
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to import ICA MCP core. "
+            "Expected either bundled fallback at '_internal/ica_mcp_core.py' "
+            "or shared 'mcp-common/scripts/ica_mcp_core.py'."
+        ) from e
+
+
+core = _import_core()
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    return str(v).strip().lower() in ("1", "true", "yes", "on")
+
+
+_NAME_OK = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _sanitize(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", s)
+
+
+def _schema_size(schema: Any) -> int:
+    try:
+        return len(json.dumps(schema, separators=(",", ":"), default=str).encode("utf-8"))
+    except Exception:
+        return 0
+
+
+def _config_fingerprint(cfg: dict[str, Any]) -> str:
+    try:
+        raw = json.dumps(cfg, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    except Exception:
+        raw = repr(cfg).encode("utf-8", errors="replace")
+    return hashlib.sha1(raw).hexdigest()
+
+
+@dataclass
+class MirrorStatus:
+    sources: list[str]
+    servers_total: int
+    servers_mirrored: int
+    tools_total: int
+    tools_mirrored: int
+    truncated: bool
+    reasons: list[str]
+    blocked_servers: dict[str, str]
+
+
+@dataclass
+class _WorkerRequest:
+    op: str
+    tool_name: Optional[str] = None
+    args: Optional[dict[str, Any]] = None
+    future: Optional[asyncio.Future] = None
+
+
+class UpstreamWorker:
+    """
+    Owns one upstream stdio MCP session in a dedicated task.
+
+    This avoids AnyIO cancel-scope lifecycle mismatches by ensuring session
+    enter/use/exit all happen in the same task.
+    """
+
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        server_cfg: dict[str, Any],
+        idle_ttl_s: float,
+        request_timeout_s: float,
+        script_file: str,
+    ):
+        self.server_name = server_name
+        self.server_cfg = server_cfg
+        self.config_fingerprint = _config_fingerprint(server_cfg)
+        self.idle_ttl_s = idle_ttl_s
+        self.request_timeout_s = request_timeout_s
+        self.script_file = script_file
+
+        self._queue: asyncio.Queue[_WorkerRequest] = asyncio.Queue()
+        self._task: Optional[asyncio.Task] = None
+        self._start_lock = asyncio.Lock()
+
+    async def ensure_started(self) -> None:
+        if self._task and not self._task.done():
+            return
+        async with self._start_lock:
+            if self._task and not self._task.done():
+                return
+            self._task = asyncio.create_task(
+                self._run(),
+                name=f"ica-mcp-worker:{self.server_name}",
+            )
+
+    async def list_tools(self) -> Any:
+        return await self._request("list_tools")
+
+    async def call_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
+        return await self._request("call_tool", tool_name=tool_name, args=args)
+
+    async def _request(
+        self,
+        op: str,
+        *,
+        tool_name: Optional[str] = None,
+        args: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        await self.ensure_started()
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        await self._queue.put(_WorkerRequest(op=op, tool_name=tool_name, args=args, future=fut))
+        if self.request_timeout_s > 0:
+            return await asyncio.wait_for(fut, timeout=self.request_timeout_s)
+        return await fut
+
+    async def shutdown(self) -> None:
+        task = self._task
+        if not task:
+            return
+
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        try:
+            await self._queue.put(_WorkerRequest(op="shutdown", future=fut))
+            try:
+                await asyncio.wait_for(fut, timeout=5)
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(task, timeout=5)
+            except asyncio.TimeoutError:
+                task.cancel()
+                with contextlib.suppress(Exception):
+                    await task
+        finally:
+            self._task = None
+
+    async def _run(self) -> None:
+        stack = AsyncExitStack()
+        session: Any = None
+        try:
+            while True:
+                try:
+                    if self.idle_ttl_s > 0:
+                        req = await asyncio.wait_for(self._queue.get(), timeout=self.idle_ttl_s)
+                    else:
+                        req = await self._queue.get()
+                except asyncio.TimeoutError:
+                    # Idle timeout: recycle upstream session to release resources.
+                    if session is not None:
+                        with contextlib.suppress(Exception):
+                            await stack.aclose()
+                        stack = AsyncExitStack()
+                        session = None
+                    continue
+
+                if req.op == "shutdown":
+                    if req.future and not req.future.done():
+                        req.future.set_result({"status": "ok"})
+                    break
+
+                try:
+                    if session is None:
+                        ctx = core["create_session"](
+                            self.server_name, self.server_cfg, script_file=self.script_file
+                        )
+                        session = await stack.enter_async_context(ctx)
+
+                    if req.op == "list_tools":
+                        result = await session.list_tools()
+                    elif req.op == "call_tool":
+                        result = await session.call_tool(req.tool_name, req.args or {})
+                    else:
+                        raise ValueError(f"Unknown worker operation: {req.op}")
+
+                    if req.future and not req.future.done():
+                        req.future.set_result(result)
+                except Exception as exc:
+                    # Reset session on failures to avoid stale/broken state.
+                    with contextlib.suppress(Exception):
+                        await stack.aclose()
+                    stack = AsyncExitStack()
+                    session = None
+                    if req.future and not req.future.done():
+                        req.future.set_exception(exc)
+        finally:
+            with contextlib.suppress(Exception):
+                await stack.aclose()
+
+
+class ProxyRuntime:
+    def __init__(self):
+        self._tools_cache_ttl_s = _env_float("ICA_MCP_PROXY_TOOL_CACHE_TTL_S", 300)
+        self._max_servers = _env_int("ICA_MCP_PROXY_MAX_SERVERS", 25)
+        self._max_tools_per_server = _env_int("ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER", 200)
+        self._max_total_tools = _env_int("ICA_MCP_PROXY_MAX_TOTAL_TOOLS", 2000)
+        self._max_schema_bytes = _env_int("ICA_MCP_PROXY_MAX_SCHEMA_BYTES", 65536)
+        self._pool_stdio = _env_bool("ICA_MCP_PROXY_POOL_STDIO", True)
+        self._disable_pooling = _env_bool("ICA_MCP_PROXY_DISABLE_POOLING", False)
+        self._upstream_idle_ttl_s = _env_float("ICA_MCP_PROXY_UPSTREAM_IDLE_TTL_S", 90)
+        self._upstream_request_timeout_s = _env_float("ICA_MCP_PROXY_UPSTREAM_REQUEST_TIMEOUT_S", 120)
+
+        self._servers_loaded_at: float = 0
+        self._servers: dict[str, dict[str, Any]] = {}
+        self._sources: list[str] = []
+        self._blocked_servers: dict[str, str] = {}
+
+        self._tools_loaded_at: dict[str, float] = {}
+        self._tools_cache: dict[str, list[Any]] = {}
+        self._mirror_map: dict[str, tuple[str, str]] = {}
+        self._last_status: Optional[MirrorStatus] = None
+
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._workers: dict[str, UpstreamWorker] = {}
+        self._workers_lock = asyncio.Lock()
+
+    def _lock_for(self, server: str) -> asyncio.Lock:
+        if server not in self._locks:
+            self._locks[server] = asyncio.Lock()
+        return self._locks[server]
+
+    def _load_servers(self) -> tuple[dict[str, dict[str, Any]], list[str]]:
+        loaded = core["load_servers_merged"](script_file=__file__)
+        servers = dict(loaded.servers)
+        sources = list(loaded.sources)
+        self._blocked_servers = dict(getattr(loaded, "blocked_servers", {}) or {})
+
+        # Reserve "proxy" namespace.
+        if "proxy" in servers:
+            servers.pop("proxy", None)
+        return servers, sources
+
+    async def get_servers(self) -> tuple[dict[str, dict[str, Any]], list[str]]:
+        # Light caching; config reads are cheap but avoid hammering.
+        if time.time() - self._servers_loaded_at > 2:
+            self._servers, self._sources = self._load_servers()
+            self._servers_loaded_at = time.time()
+            await self._prune_workers(valid_servers=set(self._servers.keys()))
+        return self._servers, self._sources
+
+    def _should_pool(self, cfg: dict[str, Any]) -> bool:
+        if self._disable_pooling or not self._pool_stdio:
+            return False
+        try:
+            return core["detect_transport"](cfg) == "stdio"
+        except Exception:
+            return False
+
+    async def _get_worker(self, server_name: str, cfg: dict[str, Any]) -> UpstreamWorker:
+        cfg_fp = _config_fingerprint(cfg)
+        replaced: Optional[UpstreamWorker] = None
+        async with self._workers_lock:
+            existing = self._workers.get(server_name)
+            if existing and existing.config_fingerprint != cfg_fp:
+                replaced = existing
+                self._workers.pop(server_name, None)
+
+            worker = self._workers.get(server_name)
+            if worker is None:
+                worker = UpstreamWorker(
+                    server_name=server_name,
+                    server_cfg=cfg,
+                    idle_ttl_s=self._upstream_idle_ttl_s,
+                    request_timeout_s=self._upstream_request_timeout_s,
+                    script_file=__file__,
+                )
+                self._workers[server_name] = worker
+
+        if replaced is not None:
+            await replaced.shutdown()
+        await worker.ensure_started()
+        return worker
+
+    async def _prune_workers(self, valid_servers: set[str]) -> None:
+        stale: list[UpstreamWorker] = []
+        async with self._workers_lock:
+            for name in list(self._workers.keys()):
+                if name not in valid_servers:
+                    stale.append(self._workers.pop(name))
+        for worker in stale:
+            await worker.shutdown()
+
+    async def invalidate_worker(self, server_name: str) -> None:
+        worker: Optional[UpstreamWorker] = None
+        async with self._workers_lock:
+            worker = self._workers.pop(server_name, None)
+        if worker:
+            await worker.shutdown()
+
+    async def shutdown(self) -> None:
+        async with self._workers_lock:
+            workers = list(self._workers.values())
+            self._workers.clear()
+        for worker in workers:
+            await worker.shutdown()
+
+    async def list_upstream_tools(self, server_name: str) -> list[Any]:
+        servers, _ = await self.get_servers()
+        if server_name not in servers:
+            raise ValueError(f"Unknown upstream server: {server_name}")
+
+        # Cache per server
+        last = self._tools_loaded_at.get(server_name, 0)
+        if time.time() - last < self._tools_cache_ttl_s and server_name in self._tools_cache:
+            return self._tools_cache[server_name]
+
+        async with self._lock_for(server_name):
+            # Re-check inside lock
+            last = self._tools_loaded_at.get(server_name, 0)
+            if time.time() - last < self._tools_cache_ttl_s and server_name in self._tools_cache:
+                return self._tools_cache[server_name]
+
+            cfg = servers[server_name]
+            if self._should_pool(cfg):
+                worker = await self._get_worker(server_name, cfg)
+                res = await worker.list_tools()
+            else:
+                async with core["create_session"](server_name, cfg, script_file=__file__) as session:
+                    res = await session.list_tools()
+            tools = list(res.tools or [])
+            self._tools_cache[server_name] = tools
+            self._tools_loaded_at[server_name] = time.time()
+            return tools
+
+    async def call_upstream(self, server_name: str, tool_name: str, args: dict) -> Any:
+        servers, _ = await self.get_servers()
+        if server_name not in servers:
+            raise ValueError(f"Unknown upstream server: {server_name}")
+
+        cfg = servers[server_name]
+        if self._should_pool(cfg):
+            worker = await self._get_worker(server_name, cfg)
+            return await worker.call_tool(tool_name, args)
+
+        async with self._lock_for(server_name):
+            async with core["create_session"](server_name, cfg, script_file=__file__) as session:
+                return await session.call_tool(tool_name, args)
+
+    async def build_tool_list(self):
+        import mcp.types as types
+
+        servers, sources = await self.get_servers()
+
+        reasons: list[str] = []
+        truncated = False
+
+        broker_tools: list[types.Tool] = _broker_tool_defs()
+
+        server_names = sorted(servers.keys())
+        servers_total = len(server_names)
+        if servers_total > self._max_servers:
+            truncated = True
+            reasons.append(f"Too many servers ({servers_total}) > ICA_MCP_PROXY_MAX_SERVERS ({self._max_servers}).")
+            server_names = server_names[: self._max_servers]
+
+        mirrored: list[types.Tool] = []
+        mirror_map: dict[str, tuple[str, str]] = {}
+
+        total_tools_seen = 0
+        total_tools_mirrored = 0
+
+        for s in server_names:
+            upstream_tools = await self.list_upstream_tools(s)
+            total_tools_seen += len(upstream_tools)
+
+            tools_for_server = list(upstream_tools)[: self._max_tools_per_server]
+            if len(upstream_tools) > self._max_tools_per_server:
+                truncated = True
+                reasons.append(
+                    f"Server '{s}' tools truncated ({len(upstream_tools)}) > ICA_MCP_PROXY_MAX_TOOLS_PER_SERVER ({self._max_tools_per_server})."
+                )
+
+            for t in tools_for_server:
+                if total_tools_mirrored >= self._max_total_tools:
+                    truncated = True
+                    reasons.append(
+                        f"Total tools truncated at ICA_MCP_PROXY_MAX_TOTAL_TOOLS ({self._max_total_tools})."
+                    )
+                    break
+
+                upstream_tool_name = t.name
+                proxy_tool_name = f"{_sanitize(s)}.{_sanitize(upstream_tool_name)}"
+
+                # Ensure tool name is protocol-safe.
+                if not _NAME_OK.match(proxy_tool_name):
+                    proxy_tool_name = _sanitize(proxy_tool_name)
+
+                # Collision handling
+                if proxy_tool_name in mirror_map:
+                    # stable-ish suffix
+                    suffix = hashlib.sha1(f"{s}:{upstream_tool_name}".encode("utf-8")).hexdigest()[:6]
+                    proxy_tool_name = f"{proxy_tool_name}__{suffix}"
+
+                input_schema = getattr(t, "inputSchema", None) or {"type": "object", "additionalProperties": True}
+                output_schema = getattr(t, "outputSchema", None)
+
+                schema_bytes = _schema_size(input_schema)
+                meta = {"ica_proxy": {"upstream_server": s, "upstream_tool": upstream_tool_name}}
+
+                if schema_bytes > self._max_schema_bytes:
+                    truncated = True
+                    reasons.append(
+                        f"Tool schema truncated for '{proxy_tool_name}' ({schema_bytes} bytes) > ICA_MCP_PROXY_MAX_SCHEMA_BYTES ({self._max_schema_bytes})."
+                    )
+                    meta["ica_proxy"]["schema_truncated"] = True
+                    meta["ica_proxy"]["original_schema_bytes"] = schema_bytes
+                    input_schema = {"type": "object", "additionalProperties": True}
+
+                mirrored.append(
+                    types.Tool(
+                        name=proxy_tool_name,
+                        description=(getattr(t, "description", None) or "")[:4000] or None,
+                        inputSchema=input_schema,
+                        outputSchema=output_schema,
+                        _meta=meta,
+                    )
+                )
+                mirror_map[proxy_tool_name] = (s, upstream_tool_name)
+                total_tools_mirrored += 1
+
+            if total_tools_mirrored >= self._max_total_tools:
+                break
+
+        status = MirrorStatus(
+            sources=sources,
+            servers_total=servers_total,
+            servers_mirrored=len(server_names),
+            tools_total=total_tools_seen,
+            tools_mirrored=total_tools_mirrored,
+            truncated=truncated,
+            reasons=reasons,
+            blocked_servers=dict(self._blocked_servers),
+        )
+        self._mirror_map = mirror_map
+        self._last_status = status
+
+        # Always include mirror_status.
+        return broker_tools + mirrored
+
+    def resolve_mirror(self, proxy_tool_name: str) -> Optional[tuple[str, str]]:
+        if proxy_tool_name in self._mirror_map:
+            return self._mirror_map[proxy_tool_name]
+
+        # Fallback parse: "<server>.<tool...>"
+        if "." in proxy_tool_name:
+            server, tool = proxy_tool_name.split(".", 1)
+            return (server, tool)
+        return None
+
+    def mirror_status(self) -> dict:
+        s = self._last_status
+        if not s:
+            return {"status": "unknown", "note": "No mirror status yet. Call list_tools first."}
+        return {
+            "sources": s.sources,
+            "servers_total": s.servers_total,
+            "servers_mirrored": s.servers_mirrored,
+            "tools_total": s.tools_total,
+            "tools_mirrored": s.tools_mirrored,
+            "truncated": s.truncated,
+            "reasons": s.reasons,
+            "blocked_servers": s.blocked_servers,
+        }
+
+
+
+def _broker_tool_defs():
+    import mcp.types as types
+
+    # Minimal schemas for broker tools.
+    obj = {"type": "object", "properties": {}}
+
+    return [
+        types.Tool(
+            name="proxy.list_servers",
+            description="List configured upstream MCP servers (merged from .mcp.json and $ICA_HOME/mcp-servers.json).",
+            inputSchema=obj,
+        ),
+        types.Tool(
+            name="proxy.list_tools",
+            description="List tools from one upstream server. Args: {server, include_schema?}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "include_schema": {"type": "boolean", "default": True},
+                },
+                "required": ["server"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.call",
+            description="Call an upstream tool. Args: {server, tool, args}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "tool": {"type": "string"},
+                    "args": {"type": "object", "additionalProperties": True, "default": {}},
+                },
+                "required": ["server", "tool"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.mirror_status",
+            description="Show mirroring/truncation status and config sources.",
+            inputSchema=obj,
+        ),
+        types.Tool(
+            name="proxy.auth_start",
+            description="Start authentication for an upstream server. Args: {server, flow?}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "server": {"type": "string"},
+                    "flow": {"type": "string"},
+                },
+                "required": ["server"],
+                "additionalProperties": False,
+            },
+        ),
+        types.Tool(
+            name="proxy.auth_status",
+            description="Show cached token status for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+        types.Tool(
+            name="proxy.auth_refresh",
+            description="Force refresh/re-mint credentials for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+        types.Tool(
+            name="proxy.auth_logout",
+            description="Delete cached credentials for an upstream server. Args: {server}.",
+            inputSchema={"type": "object", "properties": {"server": {"type": "string"}}, "required": ["server"]},
+        ),
+    ]
+
+
+async def _handle_proxy_tool(rt: ProxyRuntime, tool_name: str, args: dict) -> Any:
+    servers, sources = await rt.get_servers()
+
+    if tool_name == "proxy.list_servers":
+        return {"servers": sorted(servers.keys()), "sources": sources, "blocked_servers": dict(rt._blocked_servers)}
+
+    if tool_name == "proxy.mirror_status":
+        return rt.mirror_status()
+
+    if tool_name == "proxy.list_tools":
+        s = args.get("server")
+        include_schema = bool(args.get("include_schema", True))
+        tools = await rt.list_upstream_tools(str(s))
+        out = []
+        for t in tools:
+            out.append(
+                {
+                    "name": t.name,
+                    "description": getattr(t, "description", None),
+                    "inputSchema": getattr(t, "inputSchema", None) if include_schema else None,
+                    "outputSchema": getattr(t, "outputSchema", None) if include_schema else None,
+                }
+            )
+        return {"server": str(s), "tools": out}
+
+    if tool_name == "proxy.call":
+        s = str(args.get("server"))
+        tn = str(args.get("tool"))
+        call_args = args.get("args") or {}
+        if not isinstance(call_args, dict):
+            raise ValueError("proxy.call args must be an object")
+        return await rt.call_upstream(s, tn, call_args)
+
+    if tool_name in ("proxy.auth_start", "proxy.auth_status", "proxy.auth_refresh", "proxy.auth_logout"):
+        server = str(args.get("server"))
+        if server not in servers:
+            raise ValueError(f"Unknown upstream server: {server}")
+        cfg = servers[server]
+
+        if tool_name == "proxy.auth_status":
+            entry = core["get_token_entry"](server, script_file=__file__)
+            if not entry:
+                return {"server": server, "status": "missing"}
+            return {
+                "server": server,
+                "status": "present",
+                "expires_at": entry.get("expires_at"),
+                "expired": core["token_is_expired"](entry),
+                "scope": entry.get("scope"),
+                "token_type": entry.get("token_type"),
+                "saved_to": str(core["tokens_path"](script_file=__file__) or ""),
+            }
+
+        if tool_name == "proxy.auth_logout":
+            ok = core["delete_token_entry"](server, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return {"server": server, "status": "deleted" if ok else "missing"}
+
+        oauth = core["resolve_oauth_config"](cfg)
+        if not oauth:
+            raise ValueError("Server has no oauth configuration.")
+        flow = (args.get("flow") or oauth.get("type") or "pkce").lower()
+
+        if tool_name == "proxy.auth_refresh":
+            # Force refresh: if client credentials, re-mint; else refresh token path.
+            if flow == "client_credentials":
+                out = await core["oauth_auth_client_credentials"](server, cfg, script_file=__file__)
+                await rt.invalidate_worker(server)
+                return out
+            tok = core["oauth_maybe_refresh"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return {"server": server, "status": "ok" if tok else "missing"}
+
+        # auth_start
+        if flow in ("device_code", "oidc_device_code"):
+            out = await core["oauth_auth_device_code"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return out
+        if flow == "client_credentials":
+            out = await core["oauth_auth_client_credentials"](server, cfg, script_file=__file__)
+            await rt.invalidate_worker(server)
+            return out
+        # default pkce
+        out = await core["oauth_auth_pkce"](server, cfg, script_file=__file__)
+        await rt.invalidate_worker(server)
+        return out
+
+    raise ValueError(f"Unknown proxy tool: {tool_name}")
+
+
+async def _run():
+    try:
+        import anyio
+        import mcp.types as types
+        from mcp.server.lowlevel import Server
+        from mcp.server.models import InitializationOptions
+        from mcp.server.stdio import stdio_server
+    except Exception as e:
+        raise RuntimeError(
+            "Missing MCP server dependencies. Install: pip install mcp anyio jsonschema"
+        ) from e
+
+    rt = ProxyRuntime()
+
+    server = Server("ica-mcp-proxy")
+
+    @server.list_tools()
+    async def _list_tools():
+        return await rt.build_tool_list()
+
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict):
+        if name.startswith("proxy."):
+            res = await _handle_proxy_tool(rt, name, arguments or {})
+            return res
+
+        resolved = rt.resolve_mirror(name)
+        if not resolved:
+            raise ValueError(f"Unknown tool: {name}")
+        upstream_server, upstream_tool = resolved
+        # If upstream_server was sanitized in tool name, try best-effort match.
+        # Prefer exact match; else match by sanitized name.
+        servers, _ = await rt.get_servers()
+        if upstream_server not in servers:
+            candidates = {_sanitize(k): k for k in servers.keys()}
+            if upstream_server in candidates:
+                upstream_server = candidates[upstream_server]
+        return await rt.call_upstream(upstream_server, upstream_tool, arguments or {})
+
+    capabilities = types.ServerCapabilities(tools=types.ToolsCapability(listChanged=False))
+    init = InitializationOptions(
+        server_name="ica-mcp-proxy",
+        server_version=os.environ.get("ICA_VERSION", "dev"),
+        capabilities=capabilities,
+        instructions="ICA MCP proxy: use proxy.* broker tools or call mirrored tools as <server>.<tool>.",
+    )
+
+    try:
+        async with stdio_server() as (read, write):
+            await server.run(read, write, init)
+    finally:
+        await rt.shutdown()
+
+
+def main():
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/installer/dashboard-server-plugins.test.ts
+++ b/tests/installer/dashboard-server-plugins.test.ts
@@ -80,6 +80,8 @@ test("loadDashboardServerPlugins registers only enabled plugins with scoped rout
     resolvedTarget: {
       target: "codex",
       installPath: "/tmp/.codex",
+      skillsPath: "/tmp/.codex/skills",
+      workflowsPath: "/tmp/.codex/workflows",
       scope: "user",
     },
   });
@@ -89,6 +91,8 @@ test("loadDashboardServerPlugins registers only enabled plugins with scoped rout
     resolvedTarget: {
       target: "codex",
       installPath: "/tmp/.codex",
+      skillsPath: "/tmp/.codex/skills",
+      workflowsPath: "/tmp/.codex/workflows",
       scope: "user",
     },
     report: {
@@ -96,7 +100,9 @@ test("loadDashboardServerPlugins registers only enabled plugins with scoped rout
       installPath: "/tmp/.codex",
       operation: "install",
       appliedSkills: [],
+      appliedWorkflows: [],
       removedSkills: [],
+      removedWorkflows: [],
       skippedSkills: [],
       warnings: [],
       errors: [],

--- a/tests/installer/executor.test.ts
+++ b/tests/installer/executor.test.ts
@@ -209,3 +209,332 @@ test("install fails when skill content digest changes after catalog load", async
     }
   }
 });
+
+test("antigravity install generates companion workflows and tracks them", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-antigravity-"));
+  const { sourceId, tempStateRoot } = await setupExternalSkillsSource("antigravity-workflows");
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = tempStateRoot;
+
+  try {
+    const report = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(report.targets[0].errors.length, 0);
+    assert.deepEqual(report.targets[0].appliedWorkflows, ["developer"]);
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agents", "skills", "developer", "SKILL.md")));
+    const workflowPath = path.join(tempRoot, ".agents", "workflows", "developer.md");
+    assert.ok(fs.existsSync(workflowPath));
+    const workflowBody = fs.readFileSync(workflowPath, "utf8");
+    assert.match(workflowBody, /description:\s+external test developer/i);
+    assert.match(workflowBody, /Use the developer skill for this task\./);
+
+    const state = await loadInstallState(path.join(tempRoot, ".agents"));
+    assert.ok(state);
+    assert.equal(state?.managedWorkflows.length, 1);
+    assert.equal(state?.managedWorkflows[0].name, "developer");
+
+    const uninstallReport = await executeOperation(repoRoot, {
+      operation: "uninstall",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      force: false,
+      installClaudeIntegration: false,
+    });
+    assert.equal(uninstallReport.targets[0].errors.length, 0);
+    assert.deepEqual(uninstallReport.targets[0].removedWorkflows, ["developer"]);
+    assert.equal(fs.existsSync(workflowPath), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
+test("antigravity migration moves managed assets from .agent to .agents and preserves unknown files", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-antigravity-migration-"));
+  const { sourceId, tempStateRoot } = await setupExternalSkillsSource("antigravity-migration");
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = tempStateRoot;
+
+  try {
+    const legacyInstall = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      agentDirName: ".agent",
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+    assert.equal(legacyInstall.targets[0].errors.length, 0);
+    fs.writeFileSync(path.join(tempRoot, ".agent", "user-note.txt"), "keep me", "utf8");
+
+    const migrated = await executeOperation(repoRoot, {
+      operation: "sync",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: true,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(migrated.targets[0].errors.length, 0);
+    assert.ok(migrated.targets[0].warnings.some((warning) => warning.code === "ANTIGRAVITY_LEGACY_MIGRATED"));
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agents", "skills", "developer", "SKILL.md")));
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agents", "workflows", "developer.md")));
+    assert.equal(fs.existsSync(path.join(tempRoot, ".agent", "skills", "developer")), false);
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agent", "user-note.txt")));
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
+test("antigravity prefers .agents when both .agent and .agents exist", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-antigravity-dual-"));
+  const { sourceId, tempStateRoot } = await setupExternalSkillsSource("antigravity-dual");
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = tempStateRoot;
+
+  try {
+    const initial = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+    assert.equal(initial.targets[0].errors.length, 0);
+
+    const modernStatePath = path.join(tempRoot, ".agents", ".ica", "install-state.json");
+    const legacyStatePath = path.join(tempRoot, ".agent", ".ica", "install-state.json");
+    fs.mkdirSync(path.dirname(legacyStatePath), { recursive: true });
+    fs.copyFileSync(modernStatePath, legacyStatePath);
+
+    const sync = await executeOperation(repoRoot, {
+      operation: "sync",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: true,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(sync.targets[0].errors.length, 0);
+    assert.ok(sync.targets[0].warnings.some((warning) => warning.code === "LEGACY_ANTIGRAVITY_PATH_PRESENT"));
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agents", ".ica", "install-state.json")));
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
+test("antigravity user scope migrates legacy installs from ~/.antigravity", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-antigravity-user-home-"));
+  const restoreHome = (() => {
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    return () => {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      if (previousUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = previousUserProfile;
+      }
+    };
+  })();
+  const { sourceId, tempStateRoot } = await setupExternalSkillsSource("antigravity-user-migration");
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = tempStateRoot;
+
+  try {
+    const legacyInstall = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["antigravity"],
+      scope: "user",
+      agentDirName: ".antigravity",
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+    assert.equal(legacyInstall.targets[0].errors.length, 0);
+
+    const migrated = await executeOperation(repoRoot, {
+      operation: "sync",
+      targets: ["antigravity"],
+      scope: "user",
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: true,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(migrated.targets[0].errors.length, 0);
+    assert.ok(migrated.targets[0].warnings.some((warning) => warning.code === "ANTIGRAVITY_LEGACY_MIGRATED"));
+    assert.ok(fs.existsSync(path.join(tempHome, ".gemini", "antigravity", "skills", "developer", "SKILL.md")));
+    assert.ok(fs.existsSync(path.join(tempHome, ".gemini", "antigravity", "global_workflows", "developer.md")));
+    assert.equal(fs.existsSync(path.join(tempHome, ".antigravity", "skills", "developer")), false);
+  } finally {
+    restoreHome();
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
+test("antigravity migration refuses to overwrite pre-existing .agents assets", async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-antigravity-conflict-"));
+  const { sourceId, tempStateRoot } = await setupExternalSkillsSource("antigravity-conflict");
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = tempStateRoot;
+
+  try {
+    const legacyInstall = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      agentDirName: ".agent",
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+    assert.equal(legacyInstall.targets[0].errors.length, 0);
+
+    const conflictingDestination = path.join(tempRoot, ".agents", "skills", "developer", "SKILL.md");
+    fs.mkdirSync(path.dirname(conflictingDestination), { recursive: true });
+    fs.writeFileSync(conflictingDestination, "user owned\n", "utf8");
+
+    const migrated = await executeOperation(repoRoot, {
+      operation: "sync",
+      targets: ["antigravity"],
+      scope: "project",
+      projectPath: tempRoot,
+      mode: "copy",
+      skills: [],
+      skillSelections: [
+        {
+          sourceId,
+          skillName: "developer",
+          skillId: `${sourceId}/developer`,
+        },
+      ],
+      removeUnselected: true,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(migrated.targets[0].errors.length, 1);
+    assert.match(migrated.targets[0].errors[0].message, /migration conflict/i);
+    assert.equal(fs.readFileSync(conflictingDestination, "utf8"), "user owned\n");
+    assert.ok(fs.existsSync(path.join(tempRoot, ".agent", "skills", "developer", "SKILL.md")));
+    assert.equal(fs.existsSync(path.join(tempRoot, ".agents", ".ica", "install-state.json")), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});

--- a/tests/installer/installations.test.ts
+++ b/tests/installer/installations.test.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createInstallerApiServer } from "../../src/installer-api/server/index";
+import { inspectInstallation } from "../../src/installer-core/installations";
+import { createEmptyState, saveInstallState } from "../../src/installer-core/state";
+import { resolveTargetPaths } from "../../src/installer-core/targets";
+import { ManagedSkillState, SkillCatalog } from "../../src/installer-core/types";
+
+const repoRoot = path.resolve(__dirname, "../../..");
+const API_KEY = "test-api-key";
+
+function withTempHome(tempHome: string): () => void {
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  return () => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = previousUserProfile;
+    }
+  };
+}
+
+function createCatalogFixture(): SkillCatalog {
+  return {
+    generatedAt: "1970-01-01T00:00:00.000Z",
+    source: "multi-source",
+    version: "1.0.0",
+    sources: [
+      {
+        id: "official-skills",
+        name: "Official Skills",
+        repoUrl: "https://example.invalid/official-skills.git",
+        transport: "https",
+        enabled: true,
+        official: true,
+        publishDefaultMode: "branch-pr",
+        providerHint: "github",
+        officialContributionEnabled: true,
+        removable: false,
+        skillsRoot: "/skills",
+      },
+    ],
+    skills: [
+      {
+        skillId: "official-skills/developer",
+        sourceId: "official-skills",
+        sourceName: "Official Skills",
+        sourceUrl: "https://example.invalid/official-skills.git",
+        skillName: "developer",
+        name: "developer",
+        description: "Developer skill",
+        category: "role",
+        dependencies: [],
+        resources: [],
+        sourcePath: "/tmp/skills/developer",
+        compatibleTargets: ["claude", "codex", "cursor", "gemini", "antigravity"],
+      },
+    ],
+  };
+}
+
+async function writeLegacyAntigravityUserInstall(tempHome: string, options: { includeWorkflow?: boolean } = {}): Promise<void> {
+  const legacyInstallPath = path.join(tempHome, ".antigravity");
+  const skillPath = path.join(legacyInstallPath, "skills", "developer");
+  fs.mkdirSync(skillPath, { recursive: true });
+  fs.writeFileSync(path.join(skillPath, "SKILL.md"), "---\nname: developer\n---\n", "utf8");
+
+  if (options.includeWorkflow !== false) {
+    const workflowRoot = path.join(legacyInstallPath, "global_workflows");
+    fs.mkdirSync(workflowRoot, { recursive: true });
+    fs.writeFileSync(path.join(workflowRoot, "developer.md"), "---\ndescription: legacy workflow\n---\n", "utf8");
+  }
+
+  const state = createEmptyState({
+    installerVersion: "1.0.0",
+    target: "antigravity",
+    scope: "user",
+  });
+  const managedSkill: ManagedSkillState = {
+    name: "developer",
+    skillName: "developer",
+    skillId: "official-skills/developer",
+    sourceId: "official-skills",
+    sourceUrl: "https://example.invalid/official-skills.git",
+    installMode: "copy",
+    effectiveMode: "copy",
+    destinationPath: skillPath,
+    sourcePath: "/tmp/skills/developer",
+  };
+  state.managedSkills = [managedSkill];
+  state.managedBaselinePaths = [path.join(legacyInstallPath, "skills")];
+  await saveInstallState(legacyInstallPath, state);
+}
+
+test("inspectInstallation recognizes legacy antigravity user installs and matched workflows", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installations-legacy-user-"));
+  const restoreHome = withTempHome(tempHome);
+
+  try {
+    await writeLegacyAntigravityUserInstall(tempHome);
+    const [resolved] = resolveTargetPaths(["antigravity"], "user");
+
+    const row = await inspectInstallation(resolved, createCatalogFixture());
+    assert.equal(row.installed, true);
+    assert.equal(row.installPath, path.join(tempHome, ".antigravity"));
+    assert.deepEqual(row.managedSkills.map((skill) => skill.name), ["developer"]);
+    assert.deepEqual(row.managedWorkflows.map((workflow) => workflow.name), ["developer"]);
+  } finally {
+    restoreHome();
+  }
+});
+
+test("inspectInstallation ignores unrelated antigravity workflow markdown files", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installations-stray-workflow-"));
+  const restoreHome = withTempHome(tempHome);
+
+  try {
+    const workflowRoot = path.join(tempHome, ".gemini", "antigravity", "global_workflows");
+    fs.mkdirSync(workflowRoot, { recursive: true });
+    fs.writeFileSync(path.join(workflowRoot, "custom.md"), "---\ndescription: unrelated workflow\n---\n", "utf8");
+
+    const [resolved] = resolveTargetPaths(["antigravity"], "user");
+    const row = await inspectInstallation(resolved, createCatalogFixture());
+    assert.equal(row.installed, false);
+    assert.deepEqual(row.managedWorkflows, []);
+  } finally {
+    restoreHome();
+  }
+});
+
+test("CLI list surfaces legacy antigravity user installs from the old home path", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-cli-list-legacy-user-"));
+  const restoreHome = withTempHome(tempHome);
+
+  try {
+    await writeLegacyAntigravityUserInstall(tempHome);
+
+    const output = execFileSync(
+      "node",
+      [path.join(repoRoot, "dist", "src", "installer-cli", "index.js"), "list", "--targets=antigravity", "--scope=user", "--json"],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: tempHome,
+          USERPROFILE: tempHome,
+        },
+        encoding: "utf8",
+      },
+    );
+
+    const rows = JSON.parse(output) as Array<{ installPath: string; managedSkills: string[]; managedWorkflows: string[] }>;
+    assert.equal(rows[0].installPath, path.join(tempHome, ".antigravity"));
+    assert.deepEqual(rows[0].managedSkills, ["official-skills/developer"]);
+    assert.deepEqual(rows[0].managedWorkflows, ["developer"]);
+  } finally {
+    restoreHome();
+  }
+});
+
+test("API installations endpoint ignores unrelated antigravity workflow markdown files", async (t) => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-api-installations-"));
+  const restoreHome = withTempHome(tempHome);
+  const workflowRoot = path.join(tempHome, ".gemini", "antigravity", "global_workflows");
+  fs.mkdirSync(workflowRoot, { recursive: true });
+  fs.writeFileSync(path.join(workflowRoot, "custom.md"), "---\ndescription: unrelated workflow\n---\n", "utf8");
+
+  const app = await createInstallerApiServer({
+    apiKey: API_KEY,
+    dependencies: ({
+      loadCatalogFromSources: async () => createCatalogFixture(),
+      loadHookCatalogFromSources: async () => ({
+        generatedAt: "1970-01-01T00:00:00.000Z",
+        source: "multi-source" as const,
+        version: "1.0.0",
+        sources: [],
+        hooks: [],
+      }),
+      loadSources: async () => [],
+      loadHookSources: async () => [],
+    }) as never,
+  });
+  t.after(async () => {
+    restoreHome();
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/api/v1/installations?targets=antigravity&scope=user",
+    headers: {
+      "x-ica-api-key": API_KEY,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as {
+    installations: Array<{ installed: boolean; managedWorkflows: Array<{ name: string }> }>;
+  };
+  assert.equal(payload.installations[0].installed, false);
+  assert.deepEqual(payload.installations[0].managedWorkflows, []);
+});

--- a/tests/installer/planner.test.ts
+++ b/tests/installer/planner.test.ts
@@ -35,6 +35,7 @@ test("planner computes install/remove delta", () => {
           sourcePath: "/tmp/src/skills/reviewer",
         },
       ],
+      managedWorkflows: [],
       managedBaselinePaths: [],
       history: [],
     },

--- a/tests/installer/sources.test.ts
+++ b/tests/installer/sources.test.ts
@@ -355,6 +355,7 @@ test("reconcileLegacyManagedSkills marks missing source bindings as orphaned", (
           sourcePath: "/tmp/skills/developer",
         },
       ],
+      managedWorkflows: [],
       managedBaselinePaths: [],
       history: [],
     },

--- a/tests/installer/targets.test.ts
+++ b/tests/installer/targets.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { resolveTargetPaths } from "../../src/installer-core/targets";
+
+test("antigravity project scope resolves to .agents with workflows path", () => {
+  const projectPath = "/tmp/ica-antigravity-project";
+  const [resolved] = resolveTargetPaths(["antigravity"], "project", projectPath);
+
+  assert.equal(resolved.installPath, path.join(projectPath, ".agents"));
+  assert.equal(resolved.skillsPath, path.join(projectPath, ".agents", "skills"));
+  assert.equal(resolved.workflowsPath, path.join(projectPath, ".agents", "workflows"));
+  assert.deepEqual(resolved.legacyInstallPaths, [path.join(projectPath, ".agent")]);
+});
+
+test("antigravity user scope resolves global workflows path", () => {
+  const [resolved] = resolveTargetPaths(["antigravity"], "user");
+
+  assert.match(resolved.installPath.replace(/\\/g, "/"), /\/\.gemini\/antigravity$/);
+  assert.match(resolved.workflowsPath.replace(/\\/g, "/"), /\/\.gemini\/antigravity\/global_workflows$/);
+  assert.deepEqual(resolved.legacyInstallPaths, [path.join(os.homedir(), ".antigravity")]);
+});


### PR DESCRIPTION
## Summary
- preserve legacy antigravity installs and make migration fail safely when managed destinations already exist
- share antigravity installation inspection across CLI, API, and dashboard while adding project-level ICA config and workflow defaults
- restore the MCP proxy python assets required by the full test suite

## Testing
- npm test
