### PR TITLE
feat: extend desktop release packaging contracts

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -46,6 +46,12 @@ jobs:
             dist/ica-${{ github.ref_name }}-source.zip
             dist/desktop-release-plan.json
             dist/desktop-updater-manifest.json
+            dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-windows-arm64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-linux-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-linux-arm64.package.json
             dist/SHA256SUMS.txt
           if-no-files-found: error
 
@@ -110,6 +116,12 @@ jobs:
             "dist/ica-${GITHUB_REF_NAME}-source.zip" \
             "dist/desktop-release-plan.json" \
             "dist/desktop-updater-manifest.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-macos-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-macos-arm64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-windows-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-windows-arm64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-linux-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-linux-arm64.package.json" \
             "dist/SHA256SUMS.txt"
           do
             cosign sign-blob --yes \
@@ -128,6 +140,12 @@ jobs:
             "dist/ica-${GITHUB_REF_NAME}-source.zip" \
             "dist/desktop-release-plan.json" \
             "dist/desktop-updater-manifest.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-macos-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-macos-arm64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-windows-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-windows-arm64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-linux-x64.package.json" \
+            "dist/ica-desktop-${GITHUB_REF_NAME}-linux-arm64.package.json" \
             "dist/SHA256SUMS.txt"
           do
             cosign verify-blob \
@@ -163,6 +181,36 @@ jobs:
         with:
           subject-path: dist/desktop-updater-manifest.json
 
+      - name: Attest macOS x64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json
+
+      - name: Attest macOS arm64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json
+
+      - name: Attest Windows x64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json
+
+      - name: Attest Windows arm64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-windows-arm64.package.json
+
+      - name: Attest Linux x64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-linux-x64.package.json
+
+      - name: Attest Linux arm64 desktop package plan provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/ica-desktop-${{ github.ref_name }}-linux-arm64.package.json
+
       - name: Publish GitHub release with signed assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -182,6 +230,24 @@ jobs:
             dist/desktop-updater-manifest.json
             dist/desktop-updater-manifest.json.sig
             dist/desktop-updater-manifest.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-windows-arm64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-windows-arm64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-windows-arm64.package.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-linux-x64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-linux-x64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-linux-x64.package.json.pem
+            dist/ica-desktop-${{ github.ref_name }}-linux-arm64.package.json
+            dist/ica-desktop-${{ github.ref_name }}-linux-arm64.package.json.sig
+            dist/ica-desktop-${{ github.ref_name }}-linux-arm64.package.json.pem
             dist/SHA256SUMS.txt
             dist/SHA256SUMS.txt.sig
             dist/SHA256SUMS.txt.pem

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -11,6 +11,12 @@ This repository publishes releases with a tag-driven GitHub Actions workflow:
 - `ica-<tag>-source.zip`
 - `desktop-release-plan.json`
 - `desktop-updater-manifest.json`
+- `ica-desktop-<tag>-macos-x64.package.json`
+- `ica-desktop-<tag>-macos-arm64.package.json`
+- `ica-desktop-<tag>-windows-x64.package.json`
+- `ica-desktop-<tag>-windows-arm64.package.json`
+- `ica-desktop-<tag>-linux-x64.package.json`
+- `ica-desktop-<tag>-linux-arm64.package.json`
 - `SHA256SUMS.txt`
 - Keyless signatures and certificates for each artifact (`.sig`, `.pem`)
 - GitHub artifact attestations (provenance) for each artifact
@@ -33,6 +39,7 @@ Reproducibility is enforced in two layers:
    - Uses `git archive` from the tagged commit
    - Uses `gzip -n` for deterministic gzip output
    - Generates desktop release metadata via `scripts/release/build-desktop-manifests.mjs`
+   - Emits one deterministic package-plan JSON artifact per supported OS/arch target
    - Sets `SOURCE_DATE_EPOCH`, `TZ=UTC`, and `LC_ALL=C`
 2. CI rebuild verification
    - Workflow rebuilds artifacts in a separate job
@@ -48,6 +55,16 @@ Reproducibility is enforced in two layers:
 - `contents: write` (publish release assets)
 - `id-token: write` (OIDC keyless signing)
 - `attestations: write` (artifact provenance attestations)
+
+## Desktop Packaging Contract
+
+The desktop release plan now defines a concrete package format and publish path for each supported target:
+
+- macOS x64 / arm64: DMG packaging with Apple code signing and notarization requirements
+- Windows x64 / arm64: EXE packaging with Authenticode requirements
+- Linux x64 / arm64: AppImage packaging with Cosign verification requirements
+
+Each target also emits a `.package.json` asset that captures the packaging contract used by CI and release publishing.
 
 ## Release Operator Flow
 

--- a/scripts/release/build-artifacts.sh
+++ b/scripts/release/build-artifacts.sh
@@ -69,6 +69,9 @@ sha256_file() {
   printf "%s  %s\n" "$(sha256_file "$ZIP_PATH")" "$(basename "$ZIP_PATH")"
   printf "%s  %s\n" "$(sha256_file "${OUTPUT_DIR}/desktop-release-plan.json")" "desktop-release-plan.json"
   printf "%s  %s\n" "$(sha256_file "${OUTPUT_DIR}/desktop-updater-manifest.json")" "desktop-updater-manifest.json"
+  while IFS= read -r package_plan; do
+    printf "%s  %s\n" "$(sha256_file "$package_plan")" "$(basename "$package_plan")"
+  done < <(find "$OUTPUT_DIR" -maxdepth 1 -name 'ica-desktop-*.package.json' | sort)
 } | sort >"${OUTPUT_DIR}/SHA256SUMS.txt"
 
 echo "Artifacts written to ${OUTPUT_DIR}"

--- a/scripts/release/build-desktop-manifests.mjs
+++ b/scripts/release/build-desktop-manifests.mjs
@@ -22,24 +22,67 @@ fs.mkdirSync(outputDir, { recursive: true });
 const generatedAt = resolveGeneratedAt(process.env.SOURCE_DATE_EPOCH);
 
 const targets = [
-  { platform: "darwin", arch: "x64", osToken: "macos" },
-  { platform: "darwin", arch: "arm64", osToken: "macos" },
-  { platform: "win32", arch: "x64", osToken: "windows" },
-  { platform: "win32", arch: "arm64", osToken: "windows" },
-  { platform: "linux", arch: "x64", osToken: "linux" },
-  { platform: "linux", arch: "arm64", osToken: "linux" },
+  {
+    platform: "darwin",
+    arch: "x64",
+    osToken: "macos",
+    artifactFormat: "dmg",
+    signingRequirements: ["apple-codesign", "apple-notarization"],
+  },
+  {
+    platform: "darwin",
+    arch: "arm64",
+    osToken: "macos",
+    artifactFormat: "dmg",
+    signingRequirements: ["apple-codesign", "apple-notarization"],
+  },
+  {
+    platform: "win32",
+    arch: "x64",
+    osToken: "windows",
+    artifactFormat: "exe",
+    signingRequirements: ["authenticode"],
+  },
+  {
+    platform: "win32",
+    arch: "arm64",
+    osToken: "windows",
+    artifactFormat: "exe",
+    signingRequirements: ["authenticode"],
+  },
+  {
+    platform: "linux",
+    arch: "x64",
+    osToken: "linux",
+    artifactFormat: "AppImage",
+    signingRequirements: ["cosign"],
+  },
+  {
+    platform: "linux",
+    arch: "arm64",
+    osToken: "linux",
+    artifactFormat: "AppImage",
+    signingRequirements: ["cosign"],
+  },
 ];
 
 const releaseTargets = targets.map((target) => {
   const id = `${target.platform}-${target.arch}`;
+  const artifactName = `ica-desktop-${version}-${target.osToken}-${target.arch}.${target.artifactFormat}`;
+  const publishPath = `desktop/stable/${target.platform}/${target.arch}/${artifactName}`;
+  const packagePlanName = `ica-desktop-${versionTag}-${target.osToken}-${target.arch}.package.json`;
   return {
     id,
     platform: target.platform,
     arch: target.arch,
-    artifactName: `ica-desktop-${version}-${target.osToken}-${target.arch}.zip`,
+    artifactName,
+    artifactFormat: target.artifactFormat,
+    publishPath,
+    packagePlanName,
     updaterChannel: "stable",
     signing: {
       provider: "sigstore-keyless",
+      requirements: target.signingRequirements,
     },
   };
 });
@@ -74,6 +117,26 @@ fs.writeFileSync(
   `${JSON.stringify(updaterManifest, null, 2)}\n`,
   "utf8",
 );
+
+for (const target of releaseTargets) {
+  const packagePlan = {
+    schemaVersion: 1,
+    generatedAt,
+    version,
+    platform: target.platform,
+    arch: target.arch,
+    artifactName: target.artifactName,
+    artifactFormat: target.artifactFormat,
+    publishPath: target.publishPath,
+    updaterChannel: target.updaterChannel,
+    signing: target.signing,
+  };
+  fs.writeFileSync(
+    path.join(outputDir, target.packagePlanName),
+    `${JSON.stringify(packagePlan, null, 2)}\n`,
+    "utf8",
+  );
+}
 
 function resolveGeneratedAt(sourceDateEpoch) {
   if (typeof sourceDateEpoch === "string" && /^\d+$/.test(sourceDateEpoch)) {

--- a/tests/installer/desktop-release-packaging.test.ts
+++ b/tests/installer/desktop-release-packaging.test.ts
@@ -61,6 +61,51 @@ test("desktop updater manifest defines stable feed paths for all desktop targets
   assert.ok(updaterManifest.channels.every((channel) => channel.artifactName.includes(channel.platform === "darwin" ? "macos" : channel.platform === "win32" ? "windows" : "linux")));
 });
 
+test("desktop release plan declares concrete package formats, publish paths, and platform signing requirements", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "ica-desktop-release-contract-"));
+
+  execFileSync("node", ["scripts/release/build-desktop-manifests.mjs", "v12.3.0", outDir], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+
+  const releaseManifest = JSON.parse(fs.readFileSync(path.join(outDir, "desktop-release-plan.json"), "utf8")) as {
+    targets: Array<{
+      platform: string;
+      arch: string;
+      artifactName: string;
+      artifactFormat?: string;
+      publishPath?: string;
+      signing: {
+        provider: string;
+        requirements?: string[];
+      };
+    }>;
+  };
+
+  assert.equal(releaseManifest.targets.length, 6);
+
+  for (const target of releaseManifest.targets) {
+    assert.ok(target.artifactFormat, `Expected ${target.platform}/${target.arch} to declare a package format.`);
+    assert.ok(
+      target.publishPath?.startsWith(`desktop/stable/${target.platform}/${target.arch}/`),
+      `Expected ${target.platform}/${target.arch} to publish into a stable desktop feed path.`,
+    );
+    assert.ok(
+      Array.isArray(target.signing.requirements) && target.signing.requirements.length > 0,
+      `Expected ${target.platform}/${target.arch} to declare signing requirements.`,
+    );
+
+    if (target.platform === "darwin") {
+      assert.ok(target.signing.requirements.includes("apple-notarization"));
+    } else if (target.platform === "win32") {
+      assert.ok(target.signing.requirements.includes("authenticode"));
+    } else {
+      assert.ok(target.signing.requirements.includes("cosign"));
+    }
+  }
+});
+
 test("release workflow publishes desktop release metadata alongside signed source artifacts", () => {
   const workflow = readWorkspaceFile(".github/workflows/release-sign.yml");
   const buildScript = readWorkspaceFile("scripts/release/build-artifacts.sh");
@@ -72,4 +117,30 @@ test("release workflow publishes desktop release metadata alongside signed sourc
   assert.match(workflow, /Keyless sign release artifacts/);
   assert.match(docs, /desktop-release-plan\.json/);
   assert.match(docs, /desktop-updater-manifest\.json/);
+});
+
+test("release workflow plans to publish desktop package artifacts for every supported target", () => {
+  const workflow = readWorkspaceFile(".github/workflows/release-sign.yml");
+  const docs = readWorkspaceFile("docs/release-signing.md");
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "ica-desktop-release-workflow-"));
+
+  execFileSync("node", ["scripts/release/build-desktop-manifests.mjs", "v12.3.0", outDir], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-macos-x64/);
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-macos-arm64/);
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-windows-x64/);
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-windows-arm64/);
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-linux-x64/);
+  assert.match(workflow, /ica-desktop-\$\{\{\s*github\.ref_name\s*\}\}-linux-arm64/);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-macos-x64.package.json")), true);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-macos-arm64.package.json")), true);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-windows-x64.package.json")), true);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-windows-arm64.package.json")), true);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-linux-x64.package.json")), true);
+  assert.equal(fs.existsSync(path.join(outDir, "ica-desktop-v12.3.0-linux-arm64.package.json")), true);
+  assert.match(docs, /notarization/i);
+  assert.match(docs, /Authenticode/i);
 });


### PR DESCRIPTION
## Summary
- extend desktop release metadata with per-target package format, publish path, and signing requirements
- generate deterministic per-target desktop package-plan assets and include them in checksums
- publish, sign, verify, attest, and document the desktop package-plan assets in the release workflow

## Testing
- npm run build:quick
- node --test dist/tests/installer/desktop-release-packaging.test.js dist/tests/installer/desktop-preview-startup.test.js dist/tests/installer/desktop-dashboard-build.test.js
- bash scripts/release/build-artifacts.sh v12.3.0 HEAD <tmpdir>