### PR TITLE
feat: add desktop rollout validation matrix

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -46,6 +46,7 @@ jobs:
             dist/ica-${{ github.ref_name }}-source.zip
             dist/desktop-release-plan.json
             dist/desktop-updater-manifest.json
+            dist/desktop-validation-matrix.json
             dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json
             dist/ica-desktop-${{ github.ref_name }}-macos-arm64.package.json
             dist/ica-desktop-${{ github.ref_name }}-windows-x64.package.json
@@ -116,6 +117,7 @@ jobs:
             "dist/ica-${GITHUB_REF_NAME}-source.zip" \
             "dist/desktop-release-plan.json" \
             "dist/desktop-updater-manifest.json" \
+            "dist/desktop-validation-matrix.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-macos-x64.package.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-macos-arm64.package.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-windows-x64.package.json" \
@@ -140,6 +142,7 @@ jobs:
             "dist/ica-${GITHUB_REF_NAME}-source.zip" \
             "dist/desktop-release-plan.json" \
             "dist/desktop-updater-manifest.json" \
+            "dist/desktop-validation-matrix.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-macos-x64.package.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-macos-arm64.package.json" \
             "dist/ica-desktop-${GITHUB_REF_NAME}-windows-x64.package.json" \
@@ -180,6 +183,11 @@ jobs:
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: dist/desktop-updater-manifest.json
+
+      - name: Attest desktop validation matrix provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/desktop-validation-matrix.json
 
       - name: Attest macOS x64 desktop package plan provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
@@ -230,6 +238,9 @@ jobs:
             dist/desktop-updater-manifest.json
             dist/desktop-updater-manifest.json.sig
             dist/desktop-updater-manifest.json.pem
+            dist/desktop-validation-matrix.json
+            dist/desktop-validation-matrix.json.sig
+            dist/desktop-validation-matrix.json.pem
             dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json
             dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json.sig
             dist/ica-desktop-${{ github.ref_name }}-macos-x64.package.json.pem

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -11,6 +11,7 @@ This repository publishes releases with a tag-driven GitHub Actions workflow:
 - `ica-<tag>-source.zip`
 - `desktop-release-plan.json`
 - `desktop-updater-manifest.json`
+- `desktop-validation-matrix.json`
 - `ica-desktop-<tag>-macos-x64.package.json`
 - `ica-desktop-<tag>-macos-arm64.package.json`
 - `ica-desktop-<tag>-windows-x64.package.json`
@@ -39,6 +40,7 @@ Reproducibility is enforced in two layers:
    - Uses `git archive` from the tagged commit
    - Uses `gzip -n` for deterministic gzip output
    - Generates desktop release metadata via `scripts/release/build-desktop-manifests.mjs`
+   - Generates desktop rollout validation metadata via `scripts/release/build-desktop-manifests.mjs`
    - Emits one deterministic package-plan JSON artifact per supported OS/arch target
    - Sets `SOURCE_DATE_EPOCH`, `TZ=UTC`, and `LC_ALL=C`
 2. CI rebuild verification
@@ -65,6 +67,8 @@ The desktop release plan now defines a concrete package format and publish path 
 - Linux x64 / arm64: AppImage packaging with Cosign verification requirements
 
 Each target also emits a `.package.json` asset that captures the packaging contract used by CI and release publishing.
+
+The same release metadata build now emits `desktop-validation-matrix.json`, which captures per-target smoke checks and rollout gates for release-readiness review. The operator checklist for that artifact lives in `docs/testing/desktop-rollout-validation.md`.
 
 ## Release Operator Flow
 

--- a/docs/testing/desktop-rollout-validation.md
+++ b/docs/testing/desktop-rollout-validation.md
@@ -1,0 +1,37 @@
+# Desktop Rollout Validation
+
+This repository publishes a `desktop-validation-matrix.json` artifact alongside the desktop release metadata so release operators can verify platform coverage and rollout gates before promoting a desktop release.
+
+## Validation Matrix Contents
+
+The validation matrix covers every supported desktop target:
+
+- `darwin/x64`
+- `darwin/arm64`
+- `win32/x64`
+- `win32/arm64`
+- `linux/x64`
+- `linux/arm64`
+
+Each target includes these required smoke checks:
+
+- `package-contract`: the per-target `.package.json` contract exists and matches the release plan
+- `updater-feed`: the updater feed path is stable and publishable
+- `desktop-startup`: the packaged dashboard bundle boots successfully in the desktop shell
+- `desktop-control-plane`: the Electron bridge and control-plane path stay available
+
+## Rollout Gates
+
+Every release must satisfy these rollout gates before promotion:
+
+- `reproducible-build`: release artifacts rebuild deterministically before signing
+- `signed-release-metadata`: signed release metadata is keylessly produced and verified in CI
+- `validation-matrix-published`: `desktop-validation-matrix.json` is uploaded with the signed release asset set
+
+## Operator Flow
+
+1. Push the release tag and wait for `.github/workflows/release-sign.yml` to finish.
+2. Download `desktop-release-plan.json`, `desktop-updater-manifest.json`, and `desktop-validation-matrix.json`.
+3. Confirm the target list matches the intended OS and architecture matrix.
+4. Verify the rollout gates were enforced by CI before publishing or promoting the release.
+5. Use the matrix as the release-readiness checklist for desktop rollout approval.

--- a/scripts/release/build-artifacts.sh
+++ b/scripts/release/build-artifacts.sh
@@ -69,6 +69,7 @@ sha256_file() {
   printf "%s  %s\n" "$(sha256_file "$ZIP_PATH")" "$(basename "$ZIP_PATH")"
   printf "%s  %s\n" "$(sha256_file "${OUTPUT_DIR}/desktop-release-plan.json")" "desktop-release-plan.json"
   printf "%s  %s\n" "$(sha256_file "${OUTPUT_DIR}/desktop-updater-manifest.json")" "desktop-updater-manifest.json"
+  printf "%s  %s\n" "$(sha256_file "${OUTPUT_DIR}/desktop-validation-matrix.json")" "desktop-validation-matrix.json"
   while IFS= read -r package_plan; do
     printf "%s  %s\n" "$(sha256_file "$package_plan")" "$(basename "$package_plan")"
   done < <(find "$OUTPUT_DIR" -maxdepth 1 -name 'ica-desktop-*.package.json' | sort)

--- a/scripts/release/build-desktop-manifests.mjs
+++ b/scripts/release/build-desktop-manifests.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { createDesktopSmokeChecks, desktopRolloutGates, desktopTargets } from "./desktop-targets.mjs";
 
 const [versionTag, outputDirArg] = process.argv.slice(2);
 
@@ -21,52 +22,7 @@ const outputDir = path.resolve(process.cwd(), outputDirArg);
 fs.mkdirSync(outputDir, { recursive: true });
 const generatedAt = resolveGeneratedAt(process.env.SOURCE_DATE_EPOCH);
 
-const targets = [
-  {
-    platform: "darwin",
-    arch: "x64",
-    osToken: "macos",
-    artifactFormat: "dmg",
-    signingRequirements: ["apple-codesign", "apple-notarization"],
-  },
-  {
-    platform: "darwin",
-    arch: "arm64",
-    osToken: "macos",
-    artifactFormat: "dmg",
-    signingRequirements: ["apple-codesign", "apple-notarization"],
-  },
-  {
-    platform: "win32",
-    arch: "x64",
-    osToken: "windows",
-    artifactFormat: "exe",
-    signingRequirements: ["authenticode"],
-  },
-  {
-    platform: "win32",
-    arch: "arm64",
-    osToken: "windows",
-    artifactFormat: "exe",
-    signingRequirements: ["authenticode"],
-  },
-  {
-    platform: "linux",
-    arch: "x64",
-    osToken: "linux",
-    artifactFormat: "AppImage",
-    signingRequirements: ["cosign"],
-  },
-  {
-    platform: "linux",
-    arch: "arm64",
-    osToken: "linux",
-    artifactFormat: "AppImage",
-    signingRequirements: ["cosign"],
-  },
-];
-
-const releaseTargets = targets.map((target) => {
+const releaseTargets = desktopTargets.map((target) => {
   const id = `${target.platform}-${target.arch}`;
   const artifactName = `ica-desktop-${version}-${target.osToken}-${target.arch}.${target.artifactFormat}`;
   const publishPath = `desktop/stable/${target.platform}/${target.arch}/${artifactName}`;
@@ -107,6 +63,21 @@ const updaterManifest = {
   })),
 };
 
+const validationMatrix = {
+  schemaVersion: 1,
+  generatedAt,
+  version,
+  rolloutGates: desktopRolloutGates,
+  targets: releaseTargets.map((target) => ({
+    id: target.id,
+    platform: target.platform,
+    arch: target.arch,
+    packagePlanName: target.packagePlanName,
+    updaterFeedPath: `desktop/stable/${target.platform}/${target.arch}/latest.json`,
+    smokeChecks: createDesktopSmokeChecks(),
+  })),
+};
+
 fs.writeFileSync(
   path.join(outputDir, "desktop-release-plan.json"),
   `${JSON.stringify(releasePlan, null, 2)}\n`,
@@ -115,6 +86,11 @@ fs.writeFileSync(
 fs.writeFileSync(
   path.join(outputDir, "desktop-updater-manifest.json"),
   `${JSON.stringify(updaterManifest, null, 2)}\n`,
+  "utf8",
+);
+fs.writeFileSync(
+  path.join(outputDir, "desktop-validation-matrix.json"),
+  `${JSON.stringify(validationMatrix, null, 2)}\n`,
   "utf8",
 );
 

--- a/scripts/release/desktop-targets.mjs
+++ b/scripts/release/desktop-targets.mjs
@@ -1,0 +1,87 @@
+export const desktopTargets = [
+  {
+    platform: "darwin",
+    arch: "x64",
+    osToken: "macos",
+    artifactFormat: "dmg",
+    signingRequirements: ["apple-codesign", "apple-notarization"],
+  },
+  {
+    platform: "darwin",
+    arch: "arm64",
+    osToken: "macos",
+    artifactFormat: "dmg",
+    signingRequirements: ["apple-codesign", "apple-notarization"],
+  },
+  {
+    platform: "win32",
+    arch: "x64",
+    osToken: "windows",
+    artifactFormat: "exe",
+    signingRequirements: ["authenticode"],
+  },
+  {
+    platform: "win32",
+    arch: "arm64",
+    osToken: "windows",
+    artifactFormat: "exe",
+    signingRequirements: ["authenticode"],
+  },
+  {
+    platform: "linux",
+    arch: "x64",
+    osToken: "linux",
+    artifactFormat: "AppImage",
+    signingRequirements: ["cosign"],
+  },
+  {
+    platform: "linux",
+    arch: "arm64",
+    osToken: "linux",
+    artifactFormat: "AppImage",
+    signingRequirements: ["cosign"],
+  },
+];
+
+export const desktopRolloutGates = [
+  {
+    id: "reproducible-build",
+    required: true,
+    description: "Release artifacts must rebuild deterministically before publishing.",
+  },
+  {
+    id: "signed-release-metadata",
+    required: true,
+    description: "Release metadata artifacts must be keylessly signed and verified in CI.",
+  },
+  {
+    id: "validation-matrix-published",
+    required: true,
+    description: "The desktop validation matrix must ship with the signed release metadata set.",
+  },
+];
+
+export function createDesktopSmokeChecks() {
+  return [
+    {
+      id: "package-contract",
+      required: true,
+      description: "Per-target desktop package contract exists and matches release metadata.",
+    },
+    {
+      id: "updater-feed",
+      required: true,
+      description: "Per-target updater feed path remains stable and publishable.",
+    },
+    {
+      id: "desktop-startup",
+      required: true,
+      description: "Desktop renderer boots the packaged dashboard bundle for the target.",
+    },
+    {
+      id: "desktop-control-plane",
+      required: true,
+      description: "Desktop bridge and control-plane path stay available for the target.",
+    },
+  ];
+}

--- a/tests/installer/desktop-rollout-validation.test.ts
+++ b/tests/installer/desktop-rollout-validation.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function readWorkspaceFile(relativePath: string): string {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), "utf8");
+}
+
+interface ValidationMatrixTarget {
+  id: string;
+  platform: string;
+  arch: string;
+  packagePlanName: string;
+  updaterFeedPath: string;
+  smokeChecks: Array<{ id: string; required: boolean }>;
+}
+
+interface ValidationMatrix {
+  schemaVersion: number;
+  version: string;
+  rolloutGates: Array<{ id: string; required: boolean }>;
+  targets: ValidationMatrixTarget[];
+}
+
+test("desktop validation matrix defines required rollout checks for every supported target", () => {
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "ica-desktop-validation-"));
+
+  execFileSync("node", ["scripts/release/build-desktop-manifests.mjs", "v12.3.0", outDir], {
+    cwd: process.cwd(),
+    stdio: "pipe",
+  });
+
+  const validationMatrixPath = path.join(outDir, "desktop-validation-matrix.json");
+  assert.equal(fs.existsSync(validationMatrixPath), true, "Desktop validation matrix should be generated.");
+
+  const validationMatrix = JSON.parse(fs.readFileSync(validationMatrixPath, "utf8")) as ValidationMatrix;
+  assert.equal(validationMatrix.schemaVersion, 1);
+  assert.equal(validationMatrix.version, "12.3.0");
+  assert.deepEqual(
+    validationMatrix.targets.map((target) => `${target.platform}/${target.arch}`),
+    [
+      "darwin/x64",
+      "darwin/arm64",
+      "win32/x64",
+      "win32/arm64",
+      "linux/x64",
+      "linux/arm64",
+    ],
+  );
+  assert.deepEqual(
+    validationMatrix.rolloutGates.map((gate) => gate.id).sort(),
+    ["reproducible-build", "signed-release-metadata", "validation-matrix-published"],
+  );
+
+  for (const target of validationMatrix.targets) {
+    assert.ok(target.packagePlanName.endsWith(".package.json"));
+    assert.ok(target.updaterFeedPath.startsWith("desktop/stable/"));
+    assert.deepEqual(
+      target.smokeChecks.map((check) => check.id).sort(),
+      ["desktop-control-plane", "desktop-startup", "package-contract", "updater-feed"],
+    );
+    assert.ok(target.smokeChecks.every((check) => check.required));
+  }
+});
+
+test("desktop validation matrix is included in release signing automation and operator docs", () => {
+  const buildScript = readWorkspaceFile("scripts/release/build-artifacts.sh");
+  const workflow = readWorkspaceFile(".github/workflows/release-sign.yml");
+  const releaseDocs = readWorkspaceFile("docs/release-signing.md");
+  const rolloutDocsPath = path.resolve(process.cwd(), "docs/testing/desktop-rollout-validation.md");
+
+  assert.match(buildScript, /desktop-validation-matrix\.json/);
+  assert.match(workflow, /desktop-validation-matrix\.json/);
+  assert.equal(fs.existsSync(rolloutDocsPath), true, "Rollout validation operator guide should exist.");
+
+  const rolloutDocs = fs.readFileSync(rolloutDocsPath, "utf8");
+  assert.match(releaseDocs, /desktop-validation-matrix\.json/);
+  assert.match(rolloutDocs, /desktop-validation-matrix\.json/);
+  assert.match(rolloutDocs, /reproducible/i);
+  assert.match(rolloutDocs, /signed release metadata/i);
+});


### PR DESCRIPTION
## Summary
- add a dedicated desktop rollout validation matrix artifact to the release metadata set
- wire the new artifact through checksums, signing, attestation, and release publishing
- document rollout validation and add automated tests for the new contract

## Changes
- generate `desktop-validation-matrix.json` from the desktop release manifest pipeline
- extract shared desktop target metadata to keep packaging and validation artifacts aligned
- add rollout validation docs and a focused desktop validation test

## Test Plan
- [x] `npm run build:quick && node --test dist/tests/installer/desktop-rollout-validation.test.js dist/tests/installer/desktop-release-packaging.test.js dist/tests/installer/desktop-preview-startup.test.js dist/tests/installer/desktop-dashboard-build.test.js`
- [x] `npm test`
- [x] local Electron renderer/runtime smoke verification
- [x] local Electron install/uninstall E2E flow against a temp project

## Breaking Changes
- None