### PR TITLE
feat: remove legacy browser cli commands

### DIFF
--- a/scripts/bootstrap/install.ps1
+++ b/scripts/bootstrap/install.ps1
@@ -93,7 +93,7 @@ node '$entryPoint' @args
     Write-Host "ICA installed ($versionTag)."
     Write-Host "Next steps:"
     Write-Host "  1) Install skills/hooks: ica install"
-    Write-Host "  2) Launch dashboard:    ica serve --open=true"
+    Write-Host "  2) Start desktop app:   npm run start:desktop"
 }
 finally {
     Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/bootstrap/install.sh
+++ b/scripts/bootstrap/install.sh
@@ -92,4 +92,4 @@ fi
 echo "ICA installed (${version_tag})."
 echo "Next steps:"
 echo "  1) Install skills/hooks: ica install"
-echo "  2) Launch dashboard:    ica serve --open=true"
+echo "  2) Start desktop app:   npm run start:desktop"

--- a/src/installer-cli/index.ts
+++ b/src/installer-cli/index.ts
@@ -40,6 +40,8 @@ interface ParsedArgs {
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_DASHBOARD_IMAGE = "ghcr.io/intelligentcode-ai/ica-installer-dashboard:main";
+const REMOVED_BROWSER_COMMANDS_MESSAGE =
+  "Legacy browser commands: `ica serve` and `ica launch` have been removed. Use `npm run start:desktop` for the local desktop workflow.";
 
 export type ServeImageBuildMode = "auto" | "always" | "never";
 export type ServeReusePortsMode = boolean;
@@ -639,10 +641,10 @@ function printHelp(): void {
   output.write(`  ica hooks install [--targets=claude,gemini] [--scope=user|project] [--project-path=/path] [--mode=symlink|copy] [--hooks=<source/hook,...>]\n`);
   output.write(`  ica hooks uninstall [--targets=claude,gemini] [--scope=user|project] [--project-path=/path] [--mode=symlink|copy] [--hooks=<source/hook,...>]\n`);
   output.write(`  ica hooks sync [--targets=claude,gemini] [--scope=user|project] [--project-path=/path] [--mode=symlink|copy] [--hooks=<source/hook,...>]\n\n`);
-  output.write(
-    `  ica serve [--host=127.0.0.1] [--ui-port=4173] [--open=true|false] [--api-port=4174] [--reuse-ports=true|false] [--image=ghcr.io/intelligentcode-ai/ica-installer-dashboard:main] [--build-image=auto|always|never]\n`,
-  );
-  output.write(`  ica launch (alias for serve; deprecated)\n\n`);
+  output.write(`Desktop workflow:\n`);
+  output.write(`  npm run start:desktop\n\n`);
+  output.write(`Removed commands:\n`);
+  output.write(`  ${REMOVED_BROWSER_COMMANDS_MESSAGE}\n\n`);
   output.write(`  Note: repository registration is unified. Adding one source auto-registers both skills and hooks mirrors.\n\n`);
   output.write(`Common flags:\n`);
   output.write(`  --targets=claude,codex\n`);
@@ -660,7 +662,6 @@ function printHelp(): void {
   output.write(`  --yes\n`);
   output.write(`  --json\n`);
   output.write(`  --refresh (for catalog: force live source refresh)\n`);
-  output.write(`  --sources-refresh-minutes=60 (serve only; set 0 to disable periodic source refresh)\n`);
 }
 
 function resolveInstallerVersion(repoRoot: string): string {
@@ -1505,15 +1506,19 @@ async function runServe(options: Record<string, string | boolean>): Promise<void
   }
 }
 
-async function runLaunch(options: Record<string, string | boolean>): Promise<void> {
-  output.write("Deprecation notice: `ica launch` is now an alias of `ica serve` and will be removed in a future release.\n");
-  await runServe(options);
+async function runRemovedBrowserCommand(): Promise<void> {
+  throw new Error(REMOVED_BROWSER_COMMANDS_MESSAGE);
 }
 
 async function main(): Promise<void> {
   const { command, options, positionals } = parseArgv(process.argv.slice(2));
   const normalized = command.toLowerCase();
   const repoRoot = findRepoRoot(__dirname);
+
+  if (normalized === "serve" || normalized === "launch") {
+    await runRemovedBrowserCommand();
+    return;
+  }
 
   if (normalized !== "help") {
     await refreshSourcesOnCliStart();
@@ -1552,16 +1557,6 @@ async function main(): Promise<void> {
 
   if (normalized === "hooks") {
     await runHooks(positionals, options);
-    return;
-  }
-
-  if (normalized === "serve") {
-    await runServe(options);
-    return;
-  }
-
-  if (normalized === "launch") {
-    await runLaunch(options);
     return;
   }
 

--- a/tests/installer/bootstrap-launch.test.ts
+++ b/tests/installer/bootstrap-launch.test.ts
@@ -13,11 +13,12 @@ test("bootstrap shell installer pulls source release artifact", () => {
   assert.match(source, /source\.tar\.gz/, "install.sh should reference source tarball artifacts");
 });
 
-test("bootstrap shell installer documents dashboard serve command", () => {
+test("bootstrap shell installer documents the desktop startup workflow", () => {
   const scriptPath = path.join(repoRoot, "scripts/bootstrap/install.sh");
   const source = fs.readFileSync(scriptPath, "utf8");
 
-  assert.match(source, /\bica serve\b/, "install.sh should tell users how to serve the dashboard");
+  assert.match(source, /\bnpm run start:desktop\b/, "install.sh should point users to the desktop workflow");
+  assert.doesNotMatch(source, /\bica serve\b/, "install.sh should not recommend the removed browser serve command");
 });
 
 test("bootstrap powershell installer pulls source release artifact", () => {
@@ -27,19 +28,25 @@ test("bootstrap powershell installer pulls source release artifact", () => {
   assert.match(source, /source\.tar\.gz/, "install.ps1 should reference source tarball artifacts");
 });
 
-test("bootstrap powershell installer documents dashboard serve command", () => {
+test("bootstrap powershell installer documents the desktop startup workflow", () => {
   const scriptPath = path.join(repoRoot, "scripts/bootstrap/install.ps1");
   const source = fs.readFileSync(scriptPath, "utf8");
 
-  assert.match(source, /\bica serve\b/i, "install.ps1 should tell users how to serve the dashboard");
+  assert.match(source, /\bnpm run start:desktop\b/i, "install.ps1 should point users to the desktop workflow");
+  assert.doesNotMatch(source, /\bica serve\b/i, "install.ps1 should not recommend the removed browser serve command");
 });
 
-test("CLI help exposes dashboard serve command and launch alias", () => {
+test("CLI help lists desktop startup guidance and removed browser command notice", () => {
   const cliPath = path.join(repoRoot, "dist/src/installer-cli/index.js");
   const result = spawnSync(process.execPath, [cliPath], { cwd: repoRoot, encoding: "utf8" });
+
   assert.equal(result.status, 0, "CLI help should exit cleanly");
-  assert.match(result.stdout, /\bica serve\b/, "CLI help should include serve command");
-  assert.match(result.stdout, /\bica launch\b/, "CLI help should include launch alias");
-  assert.match(result.stdout, /--build-image=auto\|always\|never/, "CLI help should document serve image build mode");
-  assert.match(result.stdout, /--reuse-ports=true\|false/, "CLI help should document serve port reuse mode");
+  assert.match(result.stdout, /npm run start:desktop/, "CLI help should include desktop startup guidance");
+  assert.match(
+    result.stdout,
+    /Legacy browser commands: `ica serve` and `ica launch` have been removed\./,
+    "CLI help should describe the removed browser commands",
+  );
+  assert.doesNotMatch(result.stdout, /--build-image=auto\|always\|never/, "CLI help should not document removed serve-only flags");
+  assert.doesNotMatch(result.stdout, /--reuse-ports=true\|false/, "CLI help should not document removed serve-only flags");
 });

--- a/tests/installer/cli-serve.test.ts
+++ b/tests/installer/cli-serve.test.ts
@@ -1,21 +1,58 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
-function readFile(relativePath: string): string {
-  return fs.readFileSync(path.resolve(process.cwd(), relativePath), "utf8");
+const repoRoot = process.cwd();
+const cliPath = path.join(repoRoot, "dist", "src", "installer-cli", "index.js");
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 20000,
+    killSignal: "SIGKILL",
+  });
 }
 
-test("CLI help advertises serve/launch commands", () => {
-  const cli = readFile("src/installer-cli/index.ts");
-  assert.match(cli, /ica serve \[--host=127\.0\.0\.1\] \[--ui-port=4173\] \[--open=true\|false\]/);
-  assert.match(cli, /ica launch \(alias for serve; deprecated\)/);
+test("CLI help promotes desktop-first startup and no longer advertises browser serve workflows", () => {
+  const result = runCli([]);
+
+  assert.equal(result.status, 0, "CLI help should exit cleanly");
+  assert.match(result.stdout, /npm run start:desktop/, "CLI help should direct local users to the desktop workflow");
+  assert.match(
+    result.stdout,
+    /Legacy browser commands: `ica serve` and `ica launch` have been removed\./,
+    "CLI help should explain the browser-command migration",
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /ica serve \[--host=127\.0\.0\.1\]/,
+    "CLI help should not advertise the removed serve workflow as supported",
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /ica launch \(alias for serve; deprecated\)/,
+    "CLI help should not advertise the removed launch alias as supported",
+  );
 });
 
-test("CLI main dispatch handles serve and launch", () => {
-  const cli = readFile("src/installer-cli/index.ts");
-  assert.match(cli, /if \(normalized === "serve"\) \{/);
-  assert.match(cli, /if \(normalized === "launch"\) \{/);
-  assert.match(cli, /await runServe\(options\);/);
-});
+for (const command of ["serve", "launch"]) {
+  test(`CLI ${command} fails fast with the shared desktop migration message`, () => {
+    const result = runCli([command]);
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    assert.notEqual(result.status, 0, `${command} should exit non-zero once removed`);
+    assert.match(
+      output,
+      /Legacy browser commands: `ica serve` and `ica launch` have been removed\./,
+      `${command} should explain that the browser commands were removed`,
+    );
+    assert.match(output, /npm run start:desktop/, `${command} should point users to the desktop entrypoint`);
+    assert.doesNotMatch(
+      output,
+      /alias of `ica serve`/,
+      `${command} should not describe launch as a still-working alias`,
+    );
+  });
+}

--- a/tests/installer/serve-orchestration.test.ts
+++ b/tests/installer/serve-orchestration.test.ts
@@ -5,53 +5,30 @@ import path from "node:path";
 
 const repoRoot = process.cwd();
 
-test("serve orchestrates both API and BFF runtimes", () => {
-  const cliPath = path.join(repoRoot, "src/installer-cli/index.ts");
-  const source = fs.readFileSync(cliPath, "utf8");
+function readCliSource(): string {
+  return fs.readFileSync(path.join(repoRoot, "src/installer-cli/index.ts"), "utf8");
+}
 
-  assert.match(source, /"installer-api",\s*"server",\s*"index\.js"/, "serve should reference installer API runtime");
-  assert.match(source, /"installer-bff",\s*"server",\s*"index\.js"/, "serve should reference installer BFF runtime");
-  assert.match(source, /spawn\(process\.execPath,\s*\[apiScript\]/, "serve should spawn API runtime process");
-  assert.match(source, /spawn\(process\.execPath,\s*\[bffScript\]/, "serve should spawn BFF runtime process");
+test("serve and launch share a single removed-command helper", () => {
+  const source = readCliSource();
+
+  assert.match(source, /async function runRemovedBrowserCommand\(/, "CLI should define one shared browser-command removal helper");
+  assert.match(source, /if \(normalized === "serve" \|\| normalized === "launch"\) \{/, "serve and launch should use the same dispatch path");
 });
 
-test("serve maps frontend container to localhost-only internal port without bind mounts", () => {
-  const cliPath = path.join(repoRoot, "src/installer-cli/index.ts");
-  const source = fs.readFileSync(cliPath, "utf8");
+test("launch no longer delegates to the legacy serve runtime", () => {
+  const source = readCliSource();
 
-  assert.match(source, /Math\.max\(uiPort,\s*apiPort\)\s*\+\s*1/, "serve should pick a non-conflicting default internal UI port");
-  assert.match(source, /127\.0\.0\.1:\$\{uiContainerPort\}:80/, "serve should publish container on loopback only");
-  assert.doesNotMatch(source, /\b-v\b|\s--volume\b/, "serve docker run args should not include bind mounts");
+  assert.doesNotMatch(source, /await runLaunch\(options\);/, "main dispatch should not invoke a dedicated launch alias path");
+  assert.doesNotMatch(source, /await runServe\(options\);/, "legacy browser runtime should not remain reachable from CLI dispatch");
+  assert.doesNotMatch(source, /alias of `ica serve`/, "source should not describe launch as a still-working alias");
 });
 
-test("serve reclaims internal static UI port when reuse mode is active", () => {
-  const cliPath = path.join(repoRoot, "src/installer-cli/index.ts");
-  const source = fs.readFileSync(cliPath, "utf8");
+test("help text treats serve-only flags as removed browser-runtime details", () => {
+  const source = readCliSource();
 
-  assert.match(
-    source,
-    /await reclaimDockerPublishedPort\(uiContainerPort,\s*containerName\)/,
-    "serve should reclaim existing dashboard containers bound to the internal static UI port",
-  );
-});
-
-test("serve only reclaims API/UI ports for ICA-owned processes", () => {
-  const cliPath = path.join(repoRoot, "src/installer-cli/index.ts");
-  const source = fs.readFileSync(cliPath, "utf8");
-
-  assert.match(
-    source,
-    /await isIcaOwnedServePid\(pid\)/,
-    "serve should verify process ownership before terminating listeners on configured host ports",
-  );
-});
-
-test("serve configures BFF with API key injection upstream, not browser runtime config", () => {
-  const cliPath = path.join(repoRoot, "src/installer-cli/index.ts");
-  const source = fs.readFileSync(cliPath, "utf8");
-
-  assert.match(source, /ICA_BFF_API_KEY/, "serve should pass API key to BFF process");
-  assert.match(source, /ICA_BFF_API_ORIGIN/, "serve should pass API origin to BFF process");
-  assert.match(source, /ICA_BFF_STATIC_ORIGIN/, "serve should pass static UI origin to BFF process");
-  assert.doesNotMatch(source, /ICA_UI_API_KEY/, "serve should not expose API key to browser/container env");
+  assert.match(source, /npm run start:desktop/, "help text should direct users to the desktop workflow");
+  assert.doesNotMatch(source, /--build-image=auto\|always\|never/, "help text should not advertise removed serve-only flags");
+  assert.doesNotMatch(source, /--reuse-ports=true\|false/, "help text should not advertise removed serve-only flags");
+  assert.doesNotMatch(source, /--sources-refresh-minutes=60 \(serve only/, "help text should not advertise removed serve-only flags");
 });


### PR DESCRIPTION
## Summary
- remove `ica serve` and `ica launch` as supported browser-runtime commands
- redirect CLI help and bootstrap guidance to the desktop workflow
- replace source-text coverage with behavior-level removal tests

## Changes
- add one shared removed-command message for `serve` and `launch`
- fail both commands immediately instead of entering the browser/Docker/BFF runtime
- update bootstrap installers and CLI tests to reflect the desktop-first flow

## Test Plan
- [x] `./node_modules/.bin/tsc -p tsconfig.json --pretty false && node dist/src/installer-core/catalog/generateCatalog.js && node --test dist/tests/installer/cli-serve.test.js dist/tests/installer/bootstrap-launch.test.js dist/tests/installer/cli-launch-runtime.test.js dist/tests/installer/serve-orchestration.test.js dist/tests/installer/serve-image-build.test.js`
- [x] `npm test`

## Breaking Changes
- `ica serve` and `ica launch` are now recognized-but-failing removed commands that direct users to `npm run start:desktop`

## Tracking
- Implements #146
- RED: #160
- GREEN: #161
- REFACTOR: #162