### PR TITLE
feat: desktop host hard cutover

### DIFF
--- a/src/desktop-electron/bridge.ts
+++ b/src/desktop-electron/bridge.ts
@@ -5,6 +5,10 @@ export const REALTIME_EVENT_CHANNEL = "ica:realtime:event" as const;
 export const REALTIME_SUBSCRIBE_CHANNEL = "ica:realtime:subscribe" as const;
 export const REALTIME_UNSUBSCRIBE_CHANNEL = "ica:realtime:unsubscribe" as const;
 export const CONTROL_PLANE_IPC_CHANNEL = "ica:control-plane:request" as const;
+export const DESKTOP_PICK_PROJECT_IPC_CHANNEL = "ica:desktop:pick-project" as const;
+export const DESKTOP_PICK_PUBLISH_IPC_CHANNEL = "ica:desktop:pick-publish" as const;
+export const DESKTOP_RUNTIME_INFO_IPC_CHANNEL = "ica:desktop:runtime-info" as const;
+export const DESKTOP_REPORT_FAILURE_IPC_CHANNEL = "ica:desktop:report-failure" as const;
 
 export interface DesktopControlPlaneRequest {
   pathname: string;
@@ -18,6 +22,17 @@ export interface DesktopControlPlaneResponse {
   body: unknown;
 }
 
+export interface DesktopRuntimeInfo {
+  runtime: "desktop" | "web-preview";
+  hostVersion: "ica-desktop-host-v1";
+}
+
+export interface DesktopHostFailureReport {
+  reason: string;
+  context?: string;
+  details?: Record<string, unknown>;
+}
+
 export interface DesktopBridgeRequestMap {
   [CONTROL_PLANE_REQUEST_CHANNEL]: DesktopControlPlaneRequest;
 }
@@ -29,6 +44,10 @@ export interface DesktopBridgeResponseMap {
 export interface DesktopBridgeApi {
   request<K extends keyof DesktopBridgeRequestMap>(channel: K, payload: DesktopBridgeRequestMap[K]): Promise<DesktopBridgeResponseMap[K]>;
   subscribeRealtime(listener: (event: RealtimeEvent) => void): () => void;
+  pickProjectDirectory(initialPath?: string): Promise<{ path: string }>;
+  pickPublishDirectory(initialPath?: string): Promise<{ path: string }>;
+  getRuntimeInfo(): Promise<DesktopRuntimeInfo>;
+  reportRendererFailure(payload: DesktopHostFailureReport): Promise<void>;
 }
 
 declare global {

--- a/src/desktop-electron/controlPlane.ts
+++ b/src/desktop-electron/controlPlane.ts
@@ -3,11 +3,15 @@ import { createInstallerDashboardServer } from "../installer-dashboard/server/in
 import { createInstallerApplicationService, type InstallerApplicationService } from "../installer-core/applicationService";
 import { findRepoRoot } from "../installer-core/repo";
 import type { RealtimeChannel, RealtimeEvent, RealtimeEventType } from "../installer-api/server/realtime";
-import type { DesktopBridgeRequestMap, DesktopBridgeResponseMap } from "./bridge";
+import type { DesktopBridgeRequestMap, DesktopBridgeResponseMap, DesktopHostFailureReport, DesktopRuntimeInfo } from "./bridge";
 
 export interface DesktopControlPlane {
   request(payload: DesktopBridgeRequestMap["control-plane.request"]): Promise<DesktopBridgeResponseMap["control-plane.request"]>;
   subscribeRealtime(listener: (event: RealtimeEvent) => void): () => void;
+  pickProjectDirectory(initialPath?: string): Promise<{ path: string }>;
+  pickPublishDirectory(initialPath?: string): Promise<{ path: string }>;
+  getRuntimeInfo(): Promise<DesktopRuntimeInfo>;
+  reportRendererFailure(payload: DesktopHostFailureReport): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -202,6 +206,41 @@ export async function createDesktopControlPlane(options: CreateDesktopControlPla
       return () => {
         listeners.delete(listener);
       };
+    },
+
+    async pickProjectDirectory(initialPath) {
+      return applicationService.pickProjectDirectory(initialPath);
+    },
+
+    async pickPublishDirectory(initialPath) {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/skills/pick",
+        remoteAddress: "127.0.0.1",
+        headers: {
+          "content-type": "application/json",
+        },
+        payload: JSON.stringify({
+          initialPath,
+        }),
+      } as never);
+      const body = parseInjectedBody(response.body);
+      if (response.statusCode >= 400 || !body || typeof body !== "object" || typeof (body as { path?: unknown }).path !== "string") {
+        throw new Error(extractErrorMessage(body, "Skill picker failed."));
+      }
+      return { path: (body as { path: string }).path };
+    },
+
+    async getRuntimeInfo() {
+      return {
+        runtime: "desktop",
+        hostVersion: "ica-desktop-host-v1",
+      };
+    },
+
+    async reportRendererFailure(payload) {
+      const message = payload.context ? `[desktop] ${payload.context}: ${payload.reason}` : `[desktop] ${payload.reason}`;
+      console.error(message, payload.details || {});
     },
 
     async close() {

--- a/src/desktop-electron/main.ts
+++ b/src/desktop-electron/main.ts
@@ -2,9 +2,14 @@ import path from "node:path";
 import { app, BrowserWindow, ipcMain } from "electron";
 import {
   CONTROL_PLANE_IPC_CHANNEL,
+  DESKTOP_PICK_PROJECT_IPC_CHANNEL,
+  DESKTOP_PICK_PUBLISH_IPC_CHANNEL,
+  DESKTOP_REPORT_FAILURE_IPC_CHANNEL,
+  DESKTOP_RUNTIME_INFO_IPC_CHANNEL,
   REALTIME_EVENT_CHANNEL,
   REALTIME_SUBSCRIBE_CHANNEL,
   REALTIME_UNSUBSCRIBE_CHANNEL,
+  type DesktopHostFailureReport,
   type DesktopBridgeRequestMap,
 } from "./bridge";
 import { createDesktopControlPlane } from "./controlPlane";
@@ -43,6 +48,12 @@ export async function registerElectronDesktopBridge(
       throw new Error(`Unsupported desktop bridge channel '${String(channel)}'.`);
     }
     return controlPlane.request(payload);
+  });
+  ipcMain.handle(DESKTOP_PICK_PROJECT_IPC_CHANNEL, async (_event, initialPath?: string) => controlPlane.pickProjectDirectory(initialPath));
+  ipcMain.handle(DESKTOP_PICK_PUBLISH_IPC_CHANNEL, async (_event, initialPath?: string) => controlPlane.pickPublishDirectory(initialPath));
+  ipcMain.handle(DESKTOP_RUNTIME_INFO_IPC_CHANNEL, async () => controlPlane.getRuntimeInfo());
+  ipcMain.handle(DESKTOP_REPORT_FAILURE_IPC_CHANNEL, async (_event, payload: DesktopHostFailureReport) => {
+    await controlPlane.reportRendererFailure(payload);
   });
 
   ipcMain.on(REALTIME_SUBSCRIBE_CHANNEL, (event) => {
@@ -104,6 +115,10 @@ export async function registerElectronDesktopBridge(
       }
       subscriptions.clear();
       ipcMain.removeHandler(CONTROL_PLANE_IPC_CHANNEL);
+      ipcMain.removeHandler(DESKTOP_PICK_PROJECT_IPC_CHANNEL);
+      ipcMain.removeHandler(DESKTOP_PICK_PUBLISH_IPC_CHANNEL);
+      ipcMain.removeHandler(DESKTOP_RUNTIME_INFO_IPC_CHANNEL);
+      ipcMain.removeHandler(DESKTOP_REPORT_FAILURE_IPC_CHANNEL);
       ipcMain.removeAllListeners(REALTIME_SUBSCRIBE_CHANNEL);
       ipcMain.removeAllListeners(REALTIME_UNSUBSCRIBE_CHANNEL);
       await controlPlane.close();

--- a/src/desktop-electron/preload.ts
+++ b/src/desktop-electron/preload.ts
@@ -1,12 +1,18 @@
 import { contextBridge, ipcRenderer } from "electron";
 import {
   CONTROL_PLANE_IPC_CHANNEL,
+  DESKTOP_PICK_PROJECT_IPC_CHANNEL,
+  DESKTOP_PICK_PUBLISH_IPC_CHANNEL,
+  DESKTOP_REPORT_FAILURE_IPC_CHANNEL,
+  DESKTOP_RUNTIME_INFO_IPC_CHANNEL,
   REALTIME_EVENT_CHANNEL,
   REALTIME_SUBSCRIBE_CHANNEL,
   REALTIME_UNSUBSCRIBE_CHANNEL,
   type DesktopBridgeApi,
+  type DesktopHostFailureReport,
   type DesktopBridgeRequestMap,
   type DesktopBridgeResponseMap,
+  type DesktopRuntimeInfo,
   type RealtimeEvent,
 } from "./bridge";
 
@@ -29,6 +35,22 @@ const desktopBridge: DesktopBridgeApi = {
       ipcRenderer.off(REALTIME_EVENT_CHANNEL, wrappedListener);
       ipcRenderer.send(REALTIME_UNSUBSCRIBE_CHANNEL);
     };
+  },
+
+  pickProjectDirectory(initialPath) {
+    return ipcRenderer.invoke(DESKTOP_PICK_PROJECT_IPC_CHANNEL, initialPath) as Promise<{ path: string }>;
+  },
+
+  pickPublishDirectory(initialPath) {
+    return ipcRenderer.invoke(DESKTOP_PICK_PUBLISH_IPC_CHANNEL, initialPath) as Promise<{ path: string }>;
+  },
+
+  getRuntimeInfo() {
+    return ipcRenderer.invoke(DESKTOP_RUNTIME_INFO_IPC_CHANNEL) as Promise<DesktopRuntimeInfo>;
+  },
+
+  reportRendererFailure(payload) {
+    return ipcRenderer.invoke(DESKTOP_REPORT_FAILURE_IPC_CHANNEL, payload) as Promise<void>;
   },
 };
 

--- a/src/installer-dashboard/web/src/InstallerDashboard.tsx
+++ b/src/installer-dashboard/web/src/InstallerDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { controlPlaneFetch } from "./control-plane-client";
+import { controlPlaneFetch, pickProjectDirectory, pickPublishDirectory } from "./control-plane-client";
 import { describeRealtimeStatus, summarizeRealtimeEvent } from "./desktop-shell";
 import { startRealtimeClient, type RealtimeEvent, type RealtimeStatus } from "./realtime-client";
 
@@ -328,7 +328,7 @@ export function InstallerDashboard(): JSX.Element {
   const [hookReport, setHookReport] = useState<HookOperationReport | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
-  const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>("http-only");
+  const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>("disconnected");
   const [activityFeed, setActivityFeed] = useState<RealtimeEvent[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [catalogLoadingMessage, setCatalogLoadingMessage] = useState("");
@@ -1136,18 +1136,7 @@ export function InstallerDashboard(): JSX.Element {
     setError("");
     setSkillPublishResult(null);
     try {
-      const pickerRes = await controlPlaneFetch("/api/v1/skills/pick", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          initialPath: skillPublishPath.trim() || undefined,
-        }),
-      });
-      const pickerPayload = (await pickerRes.json()) as { path?: string; error?: string };
-      if (!pickerRes.ok) {
-        throw new Error(asErrorMessage(pickerPayload, "Skill picker failed."));
-      }
-      const pickedPath = pickerPayload.path?.trim();
+      const pickedPath = (await pickPublishDirectory(skillPublishPath.trim() || undefined)).path?.trim();
       if (!pickedPath) {
         return;
       }
@@ -1205,19 +1194,8 @@ export function InstallerDashboard(): JSX.Element {
     setBusy(true);
     setError("");
     try {
-      const res = await controlPlaneFetch("/api/v1/skills/pick", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          initialPath: skillPublishPath.trim() || undefined,
-        }),
-      });
-      const payload = (await res.json()) as { path?: string; error?: string };
-      if (!res.ok) {
-        throw new Error(asErrorMessage(payload, "Skill picker failed."));
-      }
-      if (payload.path) {
-        const pickedPath = payload.path.trim();
+      const pickedPath = (await pickPublishDirectory(skillPublishPath.trim() || undefined)).path?.trim();
+      if (pickedPath) {
         setSkillPublishPath(pickedPath);
         const matched = resolveSkillForPath(pickedPath);
         setPublishOriginSourceId(matched?.sourceId);
@@ -1244,17 +1222,7 @@ export function InstallerDashboard(): JSX.Element {
     setBusy(true);
     setError("");
     try {
-      const res = await controlPlaneFetch("/api/v1/projects/pick", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          initialPath: trimmedProjectPath || undefined,
-        }),
-      });
-      const payload = (await res.json()) as { path?: string; error?: string };
-      if (!res.ok) {
-        throw new Error(asErrorMessage(payload, "Project picker failed."));
-      }
+      const payload = await pickProjectDirectory(trimmedProjectPath || undefined);
       if (payload.path) {
         setProjectPath(payload.path);
       }

--- a/src/installer-dashboard/web/src/control-plane-client.ts
+++ b/src/installer-dashboard/web/src/control-plane-client.ts
@@ -1,7 +1,7 @@
-import type { RealtimeEvent } from "../../../desktop-electron/bridge";
+import type { DesktopHostFailureReport, DesktopRuntimeInfo, RealtimeEvent } from "../../../desktop-electron/bridge";
 import { CONTROL_PLANE_REQUEST_CHANNEL } from "../../../desktop-electron/bridge";
 
-export type RealtimeStatus = "connected" | "reconnecting" | "http-only";
+export type RealtimeStatus = "connected" | "reconnecting" | "disconnected" | "web-preview";
 
 interface WsSessionResponse {
   wsUrl: string;
@@ -22,6 +22,29 @@ function getDesktopBridge() {
     return undefined;
   }
   return window.icaDesktop;
+}
+
+async function resolveRuntimeInfo(): Promise<DesktopRuntimeInfo> {
+  const desktopBridge = getDesktopBridge();
+  if (desktopBridge) {
+    return desktopBridge.getRuntimeInfo();
+  }
+
+  if (typeof navigator !== "undefined" && /\bElectron\b/i.test(navigator.userAgent || "")) {
+    return {
+      runtime: "desktop",
+      hostVersion: "ica-desktop-host-v1",
+    };
+  }
+
+  return {
+    runtime: "web-preview",
+    hostVersion: "ica-desktop-host-v1",
+  };
+}
+
+function createHostBridgeUnavailableError(): Error {
+  return new Error("Desktop host bridge unavailable.");
 }
 
 function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
@@ -79,6 +102,10 @@ function asErrorMessage(error: unknown, fallback: string): string {
 export async function controlPlaneFetch(pathname: string, init?: RequestInit): Promise<Response> {
   const desktopBridge = getDesktopBridge();
   if (!desktopBridge) {
+    const runtimeInfo = await resolveRuntimeInfo();
+    if (runtimeInfo.runtime === "desktop") {
+      throw createHostBridgeUnavailableError();
+    }
     return fetch(pathname, init);
   }
 
@@ -95,6 +122,54 @@ export async function controlPlaneFetch(pathname: string, init?: RequestInit): P
   return toJsonResponse(response.body, response.status);
 }
 
+export async function pickProjectDirectory(initialPath?: string): Promise<{ path: string }> {
+  const desktopBridge = getDesktopBridge();
+  if (desktopBridge) {
+    return desktopBridge.pickProjectDirectory(initialPath);
+  }
+
+  const response = await controlPlaneFetch("/api/v1/projects/pick", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      initialPath,
+    }),
+  });
+  const payload = (await response.json()) as { path?: string; error?: string };
+  if (!response.ok || typeof payload.path !== "string") {
+    throw new Error(asErrorMessage(payload, "Project picker failed."));
+  }
+  return { path: payload.path };
+}
+
+export async function pickPublishDirectory(initialPath?: string): Promise<{ path: string }> {
+  const desktopBridge = getDesktopBridge();
+  if (desktopBridge) {
+    return desktopBridge.pickPublishDirectory(initialPath);
+  }
+
+  const response = await controlPlaneFetch("/api/v1/skills/pick", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      initialPath,
+    }),
+  });
+  const payload = (await response.json()) as { path?: string; error?: string };
+  if (!response.ok || typeof payload.path !== "string") {
+    throw new Error(asErrorMessage(payload, "Skill picker failed."));
+  }
+  return { path: payload.path };
+}
+
+export async function reportRendererFailure(payload: DesktopHostFailureReport): Promise<void> {
+  const desktopBridge = getDesktopBridge();
+  if (!desktopBridge) {
+    return;
+  }
+  await desktopBridge.reportRendererFailure(payload);
+}
+
 export function startControlPlaneRealtimeClient(options: RealtimeClientOptions = {}): () => void {
   const desktopBridge = getDesktopBridge();
   if (desktopBridge) {
@@ -105,7 +180,7 @@ export function startControlPlaneRealtimeClient(options: RealtimeClientOptions =
   }
 
   if (typeof window === "undefined" || typeof WebSocket === "undefined") {
-    options.onStatusChange?.("http-only");
+    options.onStatusChange?.("disconnected");
     return () => undefined;
   }
 
@@ -148,6 +223,13 @@ export function startControlPlaneRealtimeClient(options: RealtimeClientOptions =
     }
 
     try {
+      const runtimeInfo = await resolveRuntimeInfo();
+      if (runtimeInfo.runtime === "desktop") {
+        options.onStatusChange?.("disconnected");
+        options.onError?.(createHostBridgeUnavailableError().message);
+        return;
+      }
+
       const response = await controlPlaneFetch("/api/v1/ws/session", {
         method: "POST",
         headers: {
@@ -184,16 +266,16 @@ export function startControlPlaneRealtimeClient(options: RealtimeClientOptions =
           return;
         }
         if (!hasConnected) {
-          options.onStatusChange?.("http-only");
+          options.onStatusChange?.("web-preview");
         }
         scheduleReconnect();
       };
     } catch (error) {
       if (!stopped) {
         if (hasConnected) {
-          options.onError?.(asErrorMessage(error, "Live updates unavailable; continuing in HTTP-only mode."));
+          options.onError?.(asErrorMessage(error, "Live updates unavailable; continuing in web preview mode."));
         }
-        options.onStatusChange?.(hasConnected ? "reconnecting" : "http-only");
+        options.onStatusChange?.(hasConnected ? "reconnecting" : "web-preview");
         scheduleReconnect();
       }
     }

--- a/src/installer-dashboard/web/src/desktop-shell.ts
+++ b/src/installer-dashboard/web/src/desktop-shell.ts
@@ -56,11 +56,20 @@ export function describeRealtimeStatus(status: RealtimeStatus, context: Realtime
     };
   }
 
+  if (status === "web-preview") {
+    return {
+      tone: "warning",
+      badge: "Preview",
+      title: "Web preview active",
+      detail: "Browser preview is active. Native desktop host actions are only available in the desktop runtime.",
+    };
+  }
+
   return {
     tone: "warning",
-    badge: "Fallback",
-    title: "Browser transport active",
-    detail: "HTTP fallback is active. Native desktop actions are limited until the desktop bridge reconnects.",
+    badge: "Disconnected",
+    title: "Desktop host unavailable",
+    detail: "The desktop host bridge is unavailable. Reconnect the desktop host to restore native actions.",
   };
 }
 

--- a/tests/installer/control-plane-client.test.ts
+++ b/tests/installer/control-plane-client.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { controlPlaneFetch, startControlPlaneRealtimeClient } from "../../src/installer-dashboard/web/src/control-plane-client";
 import type { RealtimeEvent } from "../../src/desktop-electron/bridge";
 
@@ -97,6 +98,15 @@ test("controlPlaneFetch falls back to browser fetch when no desktop bridge is av
   assert.deepEqual(await response.json(), { ok: true, via: "http" });
 });
 
+test("desktop-mode renderer must fail explicitly instead of silently falling back to browser fetch when the host bridge is unavailable", () => {
+  const clientSource = fs.readFileSync(`${process.cwd()}/src/installer-dashboard/web/src/control-plane-client.ts`, "utf8");
+
+  assert.match(clientSource, /type RealtimeStatus = "connected" \| "reconnecting" \| "disconnected" \| "web-preview"/);
+  assert.match(clientSource, /getRuntimeInfo/);
+  assert.match(clientSource, /host bridge unavailable/i);
+  assert.doesNotMatch(clientSource, /if \(!desktopBridge\) {\s*return fetch\(pathname, init\);\s*}/m);
+});
+
 test("startControlPlaneRealtimeClient consumes realtime events from the desktop bridge", async (t) => {
   const statuses: string[] = [];
   const events: RealtimeEvent[] = [];
@@ -156,4 +166,12 @@ test("startControlPlaneRealtimeClient consumes realtime events from the desktop 
 
   stop();
   assert.equal(disposeCalled, true);
+});
+
+test("web preview mode remains allowed to use browser realtime fallback", () => {
+  const clientSource = fs.readFileSync(`${process.cwd()}/src/installer-dashboard/web/src/control-plane-client.ts`, "utf8");
+
+  assert.match(clientSource, /web-preview/);
+  assert.match(clientSource, /new WebSocket\(/);
+  assert.match(clientSource, /controlPlaneFetch\("\/api\/v1\/ws\/session"/);
 });

--- a/tests/installer/desktop-bridge-red-phase.test.ts
+++ b/tests/installer/desktop-bridge-red-phase.test.ts
@@ -13,6 +13,17 @@ test("desktop bridge scaffolding exists for the Electron runtime", () => {
   assert.equal(fs.existsSync(path.resolve(process.cwd(), "src/desktop-electron/main.ts")), true, "Electron main bridge should exist.");
 });
 
+test("desktop bridge contract declares typed native host capabilities for the hard cutover", () => {
+  const bridgeSource = readWorkspaceFile("src/desktop-electron/bridge.ts");
+
+  assert.match(bridgeSource, /export interface DesktopRuntimeInfo/);
+  assert.match(bridgeSource, /export interface DesktopHostFailureReport/);
+  assert.match(bridgeSource, /pickProjectDirectory\(initialPath\?: string\): Promise<\{ path: string \}>;/);
+  assert.match(bridgeSource, /pickPublishDirectory\(initialPath\?: string\): Promise<\{ path: string \}>;/);
+  assert.match(bridgeSource, /getRuntimeInfo\(\): Promise<DesktopRuntimeInfo>;/);
+  assert.match(bridgeSource, /reportRendererFailure\(payload: DesktopHostFailureReport\): Promise<void>;/);
+});
+
 test("dashboard routes control-plane requests through the transport client", () => {
   const ui = readWorkspaceFile("src/installer-dashboard/web/src/InstallerDashboard.tsx");
 
@@ -33,4 +44,13 @@ test("realtime client delegates transport work to the control-plane client", () 
 
   assert.match(realtimeClient, /startControlPlaneRealtimeClient/);
   assert.doesNotMatch(realtimeClient, /\bnew WebSocket\(/, "Renderer realtime should not open raw websocket connections directly.");
+});
+
+test("desktop renderer routes native project and publish picking through typed host methods instead of control-plane endpoints", () => {
+  const ui = readWorkspaceFile("src/installer-dashboard/web/src/InstallerDashboard.tsx");
+
+  assert.match(ui, /\bpickProjectDirectory\(/, "Desktop hard cutover should use a typed host project picker.");
+  assert.match(ui, /\bpickPublishDirectory\(/, "Desktop hard cutover should use a typed host publish picker.");
+  assert.doesNotMatch(ui, /controlPlaneFetch\("\/api\/v1\/projects\/pick"/, "Project picking should leave the generic control-plane transport.");
+  assert.doesNotMatch(ui, /controlPlaneFetch\("\/api\/v1\/skills\/pick"/, "Publish-path picking should leave the generic control-plane transport.");
 });

--- a/tests/installer/desktop-shell-ux.test.ts
+++ b/tests/installer/desktop-shell-ux.test.ts
@@ -23,7 +23,7 @@ test("desktop shell subscribes to realtime updates for connection state and acti
   const ui = readWorkspaceFile("src/installer-dashboard/web/src/InstallerDashboard.tsx");
 
   assert.match(ui, /startRealtimeClient\(/);
-  assert.match(ui, /const \[realtimeStatus, setRealtimeStatus\] = useState<RealtimeStatus>\("http-only"\)/);
+  assert.match(ui, /const \[realtimeStatus, setRealtimeStatus\] = useState<RealtimeStatus>\("disconnected"\)/);
   assert.match(ui, /const \[activityFeed, setActivityFeed\] = useState<RealtimeEvent\[]>\(\[\]\)/);
 });
 
@@ -39,8 +39,8 @@ test("describeRealtimeStatus prioritizes busy work over fallback transport messa
   assert.match(summary.title, /Operation running/i);
 });
 
-test("describeRealtimeStatus surfaces fallback mode when browser transport is active", () => {
-  const summary = describeRealtimeStatus("http-only", {
+test("describeRealtimeStatus treats missing desktop host as a disconnected desktop boundary instead of HTTP fallback", () => {
+  const summary = describeRealtimeStatus("disconnected", {
     busy: false,
     catalogLoading: false,
     error: "",
@@ -48,7 +48,8 @@ test("describeRealtimeStatus surfaces fallback mode when browser transport is ac
   });
 
   assert.equal(summary.tone, "warning");
-  assert.match(summary.detail, /HTTP fallback/i);
+  assert.doesNotMatch(summary.detail, /HTTP fallback/i);
+  assert.match(summary.detail, /desktop host|host bridge|reconnect/i);
 });
 
 test("summarizeRealtimeEvent formats operation and source lifecycle updates for the desktop activity feed", () => {


### PR DESCRIPTION
## Summary
- add typed desktop host capabilities for project/publish picking, runtime info, and renderer failure reporting
- route desktop picker flows through the typed host boundary instead of generic control-plane picker endpoints
- make desktop runtime fallback mode explicit while preserving web preview fallback behavior

## Testing
- npm run clean:compiled-tests && ./node_modules/.bin/tsc -p tsconfig.json && node --test dist/tests/installer/desktop-bridge-red-phase.test.js dist/tests/installer/control-plane-client.test.js dist/tests/installer/desktop-shell-ux.test.js
- PATH="/Users/karsten/Work/Development/intelligentcode-ai/intelligent-code-agents/node_modules/.bin:$PATH" npm test

## Tracking
- closes #174
- closes #175
- closes #176
- closes #177