### PR TITLE
fix: make ~/.ica the canonical shared config root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,22 @@ node dist/src/installer-cli/index.js install --yes \
 
 Installed files (inside agent home):
 - `skills/`
-- `ica.config.json`
 - `ica.config.default.json`
 - `ica.workflow.default.json`
 - `VERSION`
 - `.ica/install-state.json`
+
+Shared ICA config/state (global, cross-agent by default):
+- `~/.ica/ica.config.json`
+- `~/.ica/ica.workflow.json`
+- `~/.ica/tracking.config.json`
+- `~/.ica/sources.json`
+
+Agent-home overrides (optional, active runtime only):
+- `~/.codex/ica.config.json`
+- `~/.claude/ica.config.json`
+- `~/.codex/ica.workflow.json`
+- `~/.claude/ica.workflow.json`
 
 Project conventions used by skills:
 - `.agent/queue/`

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -8,11 +8,13 @@ ICA loads `ica.config.json` in this priority order:
 1. AgentTask overrides: `workflow:*` / `config:*` fields inside the AgentTask YAML
 2. Project config (preferred): `./.ica/config.json`
 3. Project config (compat): `./ica.config.json` or `./.<agent-home>/ica.config.json`
-4. User config: `~/.<agent-home>/ica.config.json` (for example `~/.claude/ica.config.json`, `~/.codex/ica.config.json`)
-5. Defaults: `ica.config.default.json`
+4. Active agent-home override: `~/.<agent-home>/ica.config.json` for the current runtime only
+5. Shared ICA global config: `~/.ica/ica.config.json` (or `$ICA_STATE_HOME/ica.config.json`)
+6. Defaults: `ica.config.default.json`
 
 Notes:
 - `<agent-home>` is the tool-specific directory ICA installs into (`.claude`, `.codex`, `.cursor`, etc.).
+- Agent-home files are overrides, not the canonical cross-agent default.
 - Claude Code also has tool config files that are separate from ICA config:
   - Hooks: `~/.claude/settings.json`
   - MCP servers: `~/.claude.json`
@@ -26,8 +28,9 @@ Workflow settings (version bump rules, PR requirements, release automation, auto
 1. AgentTask overrides (`workflow.*` inside the AgentTask YAML)
 2. Project workflow (preferred): `./.ica/workflow.json`
 3. Project workflow (compat): `./ica.workflow.json` or `./.<agent-home>/ica.workflow.json`
-4. User workflow: `~/.<agent-home>/ica.workflow.json`
-5. Defaults: `ica.workflow.default.json`
+4. Active agent-home override: `~/.<agent-home>/ica.workflow.json` for the current runtime only
+5. Shared ICA global workflow: `~/.ica/ica.workflow.json` (or `$ICA_STATE_HOME/ica.workflow.json`)
+6. Defaults: `ica.workflow.default.json`
 
 ### Enable Agent Auto-Merge (Standing Approval)
 

--- a/docs/mcp-proxy.md
+++ b/docs/mcp-proxy.md
@@ -1,6 +1,6 @@
 # MCP Proxy (ICA-Owned)
 
-This doc describes the **ICA MCP Proxy**: a local stdio MCP server you register once in your agent runtime, which then mirrors and brokers access to upstream MCP servers defined in `.mcp.json` and/or `$ICA_HOME/mcp-servers.json`.
+This doc describes the **ICA MCP Proxy**: a local stdio MCP server you register once in your agent runtime, which then mirrors and brokers access to upstream MCP servers defined in `.mcp.json`, shared ICA config under `$ICA_STATE_HOME`, and the active agent-home override under `$ICA_HOME`.
 
 ## Why A Proxy?
 
@@ -15,7 +15,8 @@ So the user only registers one MCP server: `ica-mcp-proxy`.
 
 Create one or both of:
 - project: `./.mcp.json`
-- user: `$ICA_HOME/mcp-servers.json` (or `$ICA_HOME/mcp.json`)
+- shared global: `${ICA_STATE_HOME:-$HOME/.ica}/mcp-servers.json` (or `mcp.json`)
+- active agent-home override: `$ICA_HOME/mcp-servers.json` (or `$ICA_HOME/mcp.json`)
 
 Format:
 
@@ -35,7 +36,7 @@ Format:
 ```
 
 Precedence:
-- default: `.mcp.json` overrides `$ICA_HOME/mcp-servers.json`
+- default: `.mcp.json` overrides user config; active agent-home overrides shared global config
 - set `ICA_MCP_CONFIG_PREFER_HOME=1` to flip
 
 ## Register In Your Agent Runtime
@@ -61,7 +62,7 @@ Use one of the snippets below based on your runtime. In all cases, the target co
 
 `python3 <ICA_HOME>/skills/mcp-proxy/scripts/mcp_proxy_server.py`
 
-Replace `<ICA_HOME>` with your real agent home (for example, `~/.codex`, `~/.ica`, or a project-local install path).
+Replace `<ICA_HOME>` with your real active agent home (for example, `~/.codex` or a project-local install path). Shared ICA config lives under `${ICA_STATE_HOME:-~/.ica}`.
 
 ### Codex (`~/.codex/config.toml`)
 
@@ -184,7 +185,8 @@ Example:
 ## Authentication
 
 Tokens are stored locally in:
-- `$ICA_HOME/mcp-tokens.json`
+- active agent-home override: `$ICA_HOME/mcp-tokens.json`
+- fallback shared global: `${ICA_STATE_HOME:-$HOME/.ica}/mcp-tokens.json`
 
 Auth entry points:
 - `proxy.auth_start(server, flow?)`

--- a/src/behaviors/config-system.md
+++ b/src/behaviors/config-system.md
@@ -3,10 +3,11 @@
 **MANDATORY:** Use the configuration hierarchy; do not assume defaults.
 
 ## Configuration Hierarchy (highest to lowest)
-1. Embedded AgentTask overrides  
-2. Project config: `./ica.config.json` or `./<agent_home>/ica.config.json`  
-3. User config: `$ICA_HOME/ica.config.json`  
-4. System defaults: `ica.config.default.json`
+1. Embedded AgentTask overrides
+2. Project config: `./.ica/config.json` (compat: `./ica.config.json` or `./<agent_home>/ica.config.json`)
+3. Active agent-home override: `$ICA_HOME/ica.config.json`
+4. Shared global config: `${ICA_STATE_HOME:-$HOME/.ica}/ica.config.json`
+5. System defaults: `ica.config.default.json`
 
 ## Key Settings
 - `git.*` (privacy, branch protection, PR requirement)

--- a/src/installer-core/executor.ts
+++ b/src/installer-core/executor.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { BASELINE_DIRECTORIES, BASELINE_FILES, TARGET_HOME_DIR } from "./constants";
 import { antigravityWorkflowPath, workflowNameFromSkillName } from "./antigravity";
@@ -7,6 +8,7 @@ import { findSkillById, resolveInstallSelections } from "./catalogMultiSource";
 import { copyPath, ensureDir, pathExists, removePath, trySymlinkDirectory, writeText } from "./fs";
 import { mergeMcpConfig } from "./mcp";
 import { computePlannerDelta } from "./planner";
+import { getIcaGlobalRoot } from "./runtimePaths";
 import { assertPathWithin, redactSensitive } from "./security";
 import { appendHistory, createEmptyState, getStatePath, loadInstallState, reconcileLegacyManagedSkills, saveInstallState } from "./state";
 import { computeDirectoryDigest } from "./contentDigest";
@@ -82,14 +84,101 @@ async function writeAntigravityWorkflow(
 function buildBaselinePaths(resolved: ResolvedTargetPath): string[] {
   const dirs = BASELINE_DIRECTORIES.map((dirName) => path.join(resolved.installPath, dirName));
   const files = BASELINE_FILES.map((fileName) => path.join(resolved.installPath, fileName));
-  const paths = [...dirs, ...files, resolved.skillsPath, path.join(resolved.installPath, "logs"), path.join(resolved.installPath, "ica.config.json")];
+  const paths = [...dirs, ...files, resolved.skillsPath, path.join(resolved.installPath, "logs")];
   if (isAntigravityTarget(resolved)) {
     paths.push(resolved.workflowsPath);
   }
   return paths;
 }
 
-async function installBaseline(repoRoot: string, resolved: ResolvedTargetPath, configFile?: string): Promise<void> {
+async function seedSharedGlobalConfig(
+  repoRoot: string,
+  resolved: ResolvedTargetPath,
+  report: TargetOperationReport,
+  configFile?: string,
+): Promise<void> {
+  if (resolved.scope !== "user") {
+    return;
+  }
+
+  const globalRoot = getIcaGlobalRoot();
+  await ensureDir(globalRoot);
+
+  const legacyConfigCandidates = resolved.installPath !== globalRoot
+    ? [path.join(resolved.installPath, "ica.config.json")]
+    : [];
+  const legacyWorkflowCandidates = resolved.installPath !== globalRoot
+    ? [path.join(resolved.installPath, "ica.workflow.json")]
+    : [];
+
+  for (const targetHomeDir of Object.values(TARGET_HOME_DIR)) {
+    const candidateRoot = path.join(os.homedir(), targetHomeDir);
+    if (candidateRoot === resolved.installPath || candidateRoot === globalRoot) continue;
+    legacyConfigCandidates.push(path.join(candidateRoot, "ica.config.json"));
+    legacyWorkflowCandidates.push(path.join(candidateRoot, "ica.workflow.json"));
+  }
+
+  const globalConfigPath = path.join(globalRoot, "ica.config.json");
+  if (!(await pathExists(globalConfigPath))) {
+    const existingLegacyConfigs = [];
+    for (const candidate of legacyConfigCandidates) {
+      if (await pathExists(candidate)) {
+        existingLegacyConfigs.push(candidate);
+      }
+    }
+
+    if (configFile) {
+      await copyPath(path.resolve(configFile), globalConfigPath);
+    } else if (existingLegacyConfigs.length === 1) {
+      await copyPath(existingLegacyConfigs[0], globalConfigPath);
+      pushWarning(
+        report,
+        "GLOBAL_CONFIG_MIGRATED",
+        `Seeded shared ICA config from legacy agent-home override at '${existingLegacyConfigs[0]}'.`,
+      );
+    } else {
+      if (existingLegacyConfigs.length > 1) {
+        pushWarning(
+          report,
+          "AMBIGUOUS_LEGACY_GLOBAL_CONFIG",
+          `Found multiple legacy agent-home configs; seeded '${globalConfigPath}' from defaults instead of guessing.`,
+        );
+      }
+      await copyPath(path.join(repoRoot, "ica.config.default.json"), globalConfigPath);
+    }
+  }
+
+  const globalWorkflowPath = path.join(globalRoot, "ica.workflow.json");
+  if (!(await pathExists(globalWorkflowPath))) {
+    const existingLegacyWorkflows = [];
+    for (const candidate of legacyWorkflowCandidates) {
+      if (await pathExists(candidate)) {
+        existingLegacyWorkflows.push(candidate);
+      }
+    }
+
+    if (existingLegacyWorkflows.length === 1) {
+      await copyPath(existingLegacyWorkflows[0], globalWorkflowPath);
+      pushWarning(
+        report,
+        "GLOBAL_WORKFLOW_MIGRATED",
+        `Seeded shared ICA workflow from legacy agent-home override at '${existingLegacyWorkflows[0]}'.`,
+      );
+    } else {
+      if (existingLegacyWorkflows.length > 1) {
+        pushWarning(
+          report,
+          "AMBIGUOUS_LEGACY_GLOBAL_WORKFLOW",
+          `Found multiple legacy agent-home workflows; seeded '${globalWorkflowPath}' from defaults instead of guessing.`,
+        );
+      }
+      await copyPath(path.join(repoRoot, "ica.workflow.default.json"), globalWorkflowPath);
+    }
+  }
+}
+
+async function installBaseline(repoRoot: string, resolved: ResolvedTargetPath, report: TargetOperationReport, configFile?: string): Promise<void> {
+  await seedSharedGlobalConfig(repoRoot, resolved, report, configFile);
   await ensureDir(resolved.installPath);
   await ensureDir(resolved.skillsPath);
   await ensureDir(path.join(resolved.installPath, "logs"));
@@ -112,13 +201,6 @@ async function installBaseline(repoRoot: string, resolved: ResolvedTargetPath, c
 
   const defaultWorkflowSource = path.join(repoRoot, "ica.workflow.default.json");
   await copyPath(defaultWorkflowSource, path.join(resolved.installPath, "ica.workflow.default.json"));
-
-  const targetConfig = path.join(resolved.installPath, "ica.config.json");
-  if (configFile) {
-    await copyPath(path.resolve(configFile), targetConfig);
-  } else if (!(await pathExists(targetConfig))) {
-    await copyPath(defaultConfigSource, targetConfig);
-  }
 }
 
 function pushWarning(report: TargetOperationReport, code: string, message: string): void {
@@ -498,7 +580,7 @@ async function installOrSyncTarget(
   report: TargetOperationReport,
   catalog: SkillCatalog,
 ): Promise<void> {
-  await installBaseline(repoRoot, resolved, request.configFile);
+  await installBaseline(repoRoot, resolved, report, request.configFile);
 
   const rawState = (await loadInstallState(resolved.installPath)) ||
     createEmptyState({

--- a/src/installer-core/runtimePaths.ts
+++ b/src/installer-core/runtimePaths.ts
@@ -1,0 +1,46 @@
+import os from "node:os";
+import path from "node:path";
+import { TARGET_HOME_DIR } from "./constants";
+import { TargetPlatform } from "./types";
+
+function cleanEnvPath(value: string | undefined): string | null {
+  if (!value || !value.trim()) {
+    return null;
+  }
+  return path.resolve(value.trim());
+}
+
+function normalizeTarget(value: string | undefined): TargetPlatform | null {
+  const normalized = (value || "").trim().toLowerCase();
+  if (
+    normalized === "claude" ||
+    normalized === "codex" ||
+    normalized === "cursor" ||
+    normalized === "gemini" ||
+    normalized === "antigravity"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+export function getIcaGlobalRoot(homeDir = os.homedir()): string {
+  return cleanEnvPath(process.env.ICA_STATE_HOME) ||
+    cleanEnvPath(process.env.ICA_GLOBAL_HOME) ||
+    path.resolve(homeDir, ".ica");
+}
+
+export function resolveActiveAgentHome(options: { homeDir?: string } = {}): string | null {
+  const explicitHome = cleanEnvPath(process.env.ICA_HOME);
+  if (explicitHome) {
+    return explicitHome;
+  }
+
+  const activeTarget = normalizeTarget(process.env.ICA_ACTIVE_TARGET);
+  if (!activeTarget) {
+    return null;
+  }
+
+  const homeDir = options.homeDir || os.homedir();
+  return path.resolve(homeDir, TARGET_HOME_DIR[activeTarget]);
+}

--- a/src/installer-core/trackingConfig.ts
+++ b/src/installer-core/trackingConfig.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveActiveAgentHome } from "./runtimePaths";
 
 export type TrackingProvider = "github" | "file-based" | "linear" | "jira";
 
@@ -16,6 +17,7 @@ export interface TrackingConfig {
 export interface TrackingConfigDependencies {
   cwd: string;
   icaHome?: string;
+  activeAgentHome?: string;
   homeDir: string;
   pathExists: (targetPath: string) => Promise<boolean>;
   readText: (targetPath: string) => Promise<string>;
@@ -81,21 +83,22 @@ function candidatePaths(deps: TrackingConfigDependencies): Array<{ path: string;
     source: "project",
   });
 
+  const activeAgentHome = deps.activeAgentHome && deps.activeAgentHome.trim().length > 0
+    ? deps.activeAgentHome
+    : resolveActiveAgentHome({ homeDir: deps.homeDir });
+  if (activeAgentHome) {
+    candidates.push({
+      path: path.resolve(activeAgentHome, "tracking.config.json"),
+      source: "agent-home",
+    });
+  }
+
   if (deps.icaHome && deps.icaHome.trim().length > 0) {
     candidates.push({
       path: path.resolve(deps.icaHome, "tracking.config.json"),
       source: "system",
     });
   }
-
-  candidates.push({
-    path: path.resolve(deps.homeDir, ".codex", "tracking.config.json"),
-    source: "agent-home",
-  });
-  candidates.push({
-    path: path.resolve(deps.homeDir, ".claude", "tracking.config.json"),
-    source: "agent-home",
-  });
   return candidates;
 }
 

--- a/src/skills/mcp-common/scripts/ica_mcp_core.py
+++ b/src/skills/mcp-common/scripts/ica_mcp_core.py
@@ -10,10 +10,11 @@ Responsibilities:
 - Load/merge MCP server definitions from:
   - MCP_CONFIG (inline JSON) / MCP_CONFIG_PATH (single file override)
   - project .mcp.json
-  - $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - active agent-home override: $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - shared ICA global config: $ICA_STATE_HOME/mcp-servers.json / $ICA_STATE_HOME/mcp.json
   - ~/.claude.json fallback (compat only)
 - Expand ${ENV_VAR} placeholders
-- Token store under $ICA_HOME/mcp-tokens.json
+- Token store under active agent home when available, otherwise shared ICA global root
 - OAuth flows:
   - PKCE (explicit endpoints or OIDC discovery)
   - Device code (explicit endpoints or OIDC discovery)
@@ -56,19 +57,31 @@ def missing_dep(dep: str, extra: str = "") -> None:
 
 
 # =============================================================================
-# ICA_HOME Resolution
+# ICA Runtime Resolution
 # =============================================================================
 
 def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
     """
-    Resolve ICA_HOME (agent home directory).
+    Resolve the active agent install home.
 
     Priority:
     - ICA_HOME env var
+    - ICA_ACTIVE_TARGET -> platform-specific install home
     - infer from installed skill layout: <ICA_HOME>/skills/<skill>/scripts/<file>.py
     """
     if os.environ.get("ICA_HOME"):
         return Path(os.environ["ICA_HOME"]).expanduser()
+
+    active_target = (os.environ.get("ICA_ACTIVE_TARGET") or "").strip().lower()
+    target_dirs = {
+        "claude": Path.home() / ".claude",
+        "codex": Path.home() / ".codex",
+        "cursor": Path.home() / ".cursor",
+        "gemini": Path.home() / ".gemini",
+        "antigravity": Path.home() / ".gemini" / "antigravity",
+    }
+    if active_target in target_dirs:
+        return target_dirs[active_target]
 
     if script_file:
         p = Path(script_file).resolve()
@@ -77,13 +90,29 @@ def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
             if p.parents[2].name == "skills":
                 candidate = p.parents[3]
                 # Guard: avoid treating repo layout (src/skills/...) as ICA_HOME.
-                # Installed ICA homes include VERSION at the root.
-                if (candidate / "VERSION").exists():
+                # Installed ICA homes include VERSION at the root, but repo checkouts
+                # place VERSION under src/, so exclude that layout explicitly.
+                if (candidate / "VERSION").exists() and candidate.name != "src":
                     return candidate
         except Exception:
             return None
 
     return None
+
+
+def get_ica_global_root() -> Path:
+    """
+    Resolve the shared ICA global root.
+
+    Priority:
+    - ICA_STATE_HOME env var
+    - ICA_GLOBAL_HOME env var (compat alias)
+    - ~/.ica
+    """
+    env_override = os.environ.get("ICA_STATE_HOME") or os.environ.get("ICA_GLOBAL_HOME")
+    if env_override:
+        return Path(env_override).expanduser()
+    return Path.home() / ".ica"
 
 
 # =============================================================================
@@ -138,10 +167,17 @@ def _project_mcp_path(cwd: Optional[Path] = None) -> Path:
     return (cwd or Path.cwd()) / ".mcp.json"
 
 
-def _ica_mcp_paths(ica_home: Optional[Path]) -> list[Path]:
-    if not ica_home:
-        return []
-    return [ica_home / "mcp-servers.json", ica_home / "mcp.json"]
+def _ica_mcp_paths(global_root: Path, active_agent_home: Optional[Path]) -> list[tuple[str, Path]]:
+    paths: list[tuple[str, Path]] = [
+        ("global", global_root / "mcp-servers.json"),
+        ("global", global_root / "mcp.json"),
+    ]
+    if active_agent_home and active_agent_home.resolve() != global_root.resolve():
+        paths.extend([
+            ("home", active_agent_home / "mcp-servers.json"),
+            ("home", active_agent_home / "mcp.json"),
+        ])
+    return paths
 
 
 @dataclass(frozen=True)
@@ -162,9 +198,9 @@ def trust_path(*, script_file: Optional[str] = None) -> Optional[Path]:
     if os.environ.get("ICA_MCP_TRUST_PATH"):
         return Path(os.environ["ICA_MCP_TRUST_PATH"]).expanduser()
     ica_home = get_ica_home(script_file=script_file)
-    if not ica_home:
-        return None
-    return ica_home / "mcp-trust.json"
+    if ica_home:
+        return ica_home / "mcp-trust.json"
+    return get_ica_global_root() / "mcp-trust.json"
 
 
 def load_trust_store(*, script_file: Optional[str] = None) -> dict:
@@ -186,7 +222,7 @@ def load_trust_store(*, script_file: Optional[str] = None) -> dict:
 def save_trust_store(data: dict, *, script_file: Optional[str] = None) -> None:
     path = trust_path(script_file=script_file)
     if not path:
-        raise ValueError("ICA_HOME is required to store trust state (set ICA_HOME or install into an agent home).")
+        raise ValueError("Unable to resolve an ICA trust path.")
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -300,11 +336,12 @@ def load_servers_merged(
     - MCP_CONFIG_PATH (path)   => only this, no merge
 
     Default merge:
+    - shared ICA global mcp-servers.json/mcp.json
+    - active agent-home override mcp-servers.json/mcp.json
     - project .mcp.json
-    - ICA_HOME mcp-servers.json/mcp.json
     - (fallback) ~/.claude.json if neither exists
 
-    Precedence default: project overrides ICA_HOME.
+    Precedence default: project overrides user config; active agent home overrides shared global config.
     Set ICA_MCP_CONFIG_PREFER_HOME=1 to flip.
     """
     sources: list[str] = []
@@ -342,36 +379,42 @@ def load_servers_merged(
     merged: dict[str, dict[str, Any]] = {}
 
     ica_home = get_ica_home(script_file=script_file)
+    global_root = get_ica_global_root()
     project_path = _project_mcp_path(cwd=cwd)
-    home_paths = _ica_mcp_paths(ica_home)
+    user_paths = _ica_mcp_paths(global_root, ica_home)
 
     prefer_home = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME") in ("1", "true", "TRUE", "yes", "YES")
 
     # Load layers (if present)
     project_servers: dict[str, dict[str, Any]] = {}
+    global_servers: dict[str, dict[str, Any]] = {}
     home_servers: dict[str, dict[str, Any]] = {}
 
     if project_path.exists():
         project_servers = _normalize_servers(_read_json_file(project_path))
         sources.append(f"file:{str(project_path)}")
 
-    for hp in home_paths:
-        if hp.exists():
-            home_servers = _normalize_servers(_read_json_file(hp))
-            sources.append(f"file:{str(hp)}")
-            break
+    for scope, user_path in user_paths:
+        if not user_path.exists():
+            continue
+        layer = _normalize_servers(_read_json_file(user_path))
+        sources.append(f"file:{str(user_path)}")
+        if scope == "global" and not global_servers:
+            global_servers = layer
+        elif scope == "home" and not home_servers:
+            home_servers = layer
 
     # Fallback (compat only) if nothing else exists
-    if not project_servers and not home_servers:
+    if not project_servers and not global_servers and not home_servers:
         claude = Path.home() / ".claude.json"
         if claude.exists():
             home_servers = _normalize_servers(_read_json_file(claude))
             sources.append(f"file:{str(claude)}")
 
     if prefer_home:
-        merge_layers = [("project", project_servers), ("home", home_servers)]
+        merge_layers = [("project", project_servers), ("global", global_servers), ("home", home_servers)]
     else:
-        merge_layers = [("home", home_servers), ("project", project_servers)]
+        merge_layers = [("global", global_servers), ("home", home_servers), ("project", project_servers)]
 
     for src_name, layer in merge_layers:
         for name, cfg in layer.items():
@@ -412,9 +455,9 @@ def load_servers_merged(
 
 def tokens_path(*, script_file: Optional[str] = None) -> Optional[Path]:
     ica_home = get_ica_home(script_file=script_file)
-    if not ica_home:
-        return None
-    return ica_home / "mcp-tokens.json"
+    if ica_home:
+        return ica_home / "mcp-tokens.json"
+    return get_ica_global_root() / "mcp-tokens.json"
 
 
 def load_tokens(*, script_file: Optional[str] = None) -> dict:
@@ -436,7 +479,7 @@ def load_tokens(*, script_file: Optional[str] = None) -> dict:
 def save_tokens(data: dict, *, script_file: Optional[str] = None) -> None:
     path = tokens_path(script_file=script_file)
     if not path:
-        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+        raise ValueError("Unable to resolve an ICA token path.")
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/src/skills/mcp-proxy/scripts/_internal/ica_mcp_core.py
+++ b/src/skills/mcp-proxy/scripts/_internal/ica_mcp_core.py
@@ -10,10 +10,11 @@ Responsibilities:
 - Load/merge MCP server definitions from:
   - MCP_CONFIG (inline JSON) / MCP_CONFIG_PATH (single file override)
   - project .mcp.json
-  - $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - active agent-home override: $ICA_HOME/mcp-servers.json / $ICA_HOME/mcp.json
+  - shared ICA global config: $ICA_STATE_HOME/mcp-servers.json / $ICA_STATE_HOME/mcp.json
   - ~/.claude.json fallback (compat only)
 - Expand ${ENV_VAR} placeholders
-- Token store under $ICA_HOME/mcp-tokens.json
+- Token store under active agent home when available, otherwise shared ICA global root
 - OAuth flows:
   - PKCE (explicit endpoints or OIDC discovery)
   - Device code (explicit endpoints or OIDC discovery)
@@ -56,19 +57,31 @@ def missing_dep(dep: str, extra: str = "") -> None:
 
 
 # =============================================================================
-# ICA_HOME Resolution
+# ICA Runtime Resolution
 # =============================================================================
 
 def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
     """
-    Resolve ICA_HOME (agent home directory).
+    Resolve the active agent install home.
 
     Priority:
     - ICA_HOME env var
+    - ICA_ACTIVE_TARGET -> platform-specific install home
     - infer from installed skill layout: <ICA_HOME>/skills/<skill>/scripts/<file>.py
     """
     if os.environ.get("ICA_HOME"):
         return Path(os.environ["ICA_HOME"]).expanduser()
+
+    active_target = (os.environ.get("ICA_ACTIVE_TARGET") or "").strip().lower()
+    target_dirs = {
+        "claude": Path.home() / ".claude",
+        "codex": Path.home() / ".codex",
+        "cursor": Path.home() / ".cursor",
+        "gemini": Path.home() / ".gemini",
+        "antigravity": Path.home() / ".gemini" / "antigravity",
+    }
+    if active_target in target_dirs:
+        return target_dirs[active_target]
 
     if script_file:
         p = Path(script_file).resolve()
@@ -77,13 +90,29 @@ def get_ica_home(script_file: Optional[str] = None) -> Optional[Path]:
             if p.parents[2].name == "skills":
                 candidate = p.parents[3]
                 # Guard: avoid treating repo layout (src/skills/...) as ICA_HOME.
-                # Installed ICA homes include VERSION at the root.
-                if (candidate / "VERSION").exists():
+                # Installed ICA homes include VERSION at the root, but repo checkouts
+                # place VERSION under src/, so exclude that layout explicitly.
+                if (candidate / "VERSION").exists() and candidate.name != "src":
                     return candidate
         except Exception:
             return None
 
     return None
+
+
+def get_ica_global_root() -> Path:
+    """
+    Resolve the shared ICA global root.
+
+    Priority:
+    - ICA_STATE_HOME env var
+    - ICA_GLOBAL_HOME env var (compat alias)
+    - ~/.ica
+    """
+    env_override = os.environ.get("ICA_STATE_HOME") or os.environ.get("ICA_GLOBAL_HOME")
+    if env_override:
+        return Path(env_override).expanduser()
+    return Path.home() / ".ica"
 
 
 # =============================================================================
@@ -138,10 +167,17 @@ def _project_mcp_path(cwd: Optional[Path] = None) -> Path:
     return (cwd or Path.cwd()) / ".mcp.json"
 
 
-def _ica_mcp_paths(ica_home: Optional[Path]) -> list[Path]:
-    if not ica_home:
-        return []
-    return [ica_home / "mcp-servers.json", ica_home / "mcp.json"]
+def _ica_mcp_paths(global_root: Path, active_agent_home: Optional[Path]) -> list[tuple[str, Path]]:
+    paths: list[tuple[str, Path]] = [
+        ("global", global_root / "mcp-servers.json"),
+        ("global", global_root / "mcp.json"),
+    ]
+    if active_agent_home and active_agent_home.resolve() != global_root.resolve():
+        paths.extend([
+            ("home", active_agent_home / "mcp-servers.json"),
+            ("home", active_agent_home / "mcp.json"),
+        ])
+    return paths
 
 
 @dataclass(frozen=True)
@@ -162,9 +198,9 @@ def trust_path(*, script_file: Optional[str] = None) -> Optional[Path]:
     if os.environ.get("ICA_MCP_TRUST_PATH"):
         return Path(os.environ["ICA_MCP_TRUST_PATH"]).expanduser()
     ica_home = get_ica_home(script_file=script_file)
-    if not ica_home:
-        return None
-    return ica_home / "mcp-trust.json"
+    if ica_home:
+        return ica_home / "mcp-trust.json"
+    return get_ica_global_root() / "mcp-trust.json"
 
 
 def load_trust_store(*, script_file: Optional[str] = None) -> dict:
@@ -186,7 +222,7 @@ def load_trust_store(*, script_file: Optional[str] = None) -> dict:
 def save_trust_store(data: dict, *, script_file: Optional[str] = None) -> None:
     path = trust_path(script_file=script_file)
     if not path:
-        raise ValueError("ICA_HOME is required to store trust state (set ICA_HOME or install into an agent home).")
+        raise ValueError("Unable to resolve an ICA trust path.")
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -300,11 +336,12 @@ def load_servers_merged(
     - MCP_CONFIG_PATH (path)   => only this, no merge
 
     Default merge:
+    - shared ICA global mcp-servers.json/mcp.json
+    - active agent-home override mcp-servers.json/mcp.json
     - project .mcp.json
-    - ICA_HOME mcp-servers.json/mcp.json
     - (fallback) ~/.claude.json if neither exists
 
-    Precedence default: project overrides ICA_HOME.
+    Precedence default: project overrides user config; active agent home overrides shared global config.
     Set ICA_MCP_CONFIG_PREFER_HOME=1 to flip.
     """
     sources: list[str] = []
@@ -342,36 +379,42 @@ def load_servers_merged(
     merged: dict[str, dict[str, Any]] = {}
 
     ica_home = get_ica_home(script_file=script_file)
+    global_root = get_ica_global_root()
     project_path = _project_mcp_path(cwd=cwd)
-    home_paths = _ica_mcp_paths(ica_home)
+    user_paths = _ica_mcp_paths(global_root, ica_home)
 
     prefer_home = os.environ.get("ICA_MCP_CONFIG_PREFER_HOME") in ("1", "true", "TRUE", "yes", "YES")
 
     # Load layers (if present)
     project_servers: dict[str, dict[str, Any]] = {}
+    global_servers: dict[str, dict[str, Any]] = {}
     home_servers: dict[str, dict[str, Any]] = {}
 
     if project_path.exists():
         project_servers = _normalize_servers(_read_json_file(project_path))
         sources.append(f"file:{str(project_path)}")
 
-    for hp in home_paths:
-        if hp.exists():
-            home_servers = _normalize_servers(_read_json_file(hp))
-            sources.append(f"file:{str(hp)}")
-            break
+    for scope, user_path in user_paths:
+        if not user_path.exists():
+            continue
+        layer = _normalize_servers(_read_json_file(user_path))
+        sources.append(f"file:{str(user_path)}")
+        if scope == "global" and not global_servers:
+            global_servers = layer
+        elif scope == "home" and not home_servers:
+            home_servers = layer
 
     # Fallback (compat only) if nothing else exists
-    if not project_servers and not home_servers:
+    if not project_servers and not global_servers and not home_servers:
         claude = Path.home() / ".claude.json"
         if claude.exists():
             home_servers = _normalize_servers(_read_json_file(claude))
             sources.append(f"file:{str(claude)}")
 
     if prefer_home:
-        merge_layers = [("project", project_servers), ("home", home_servers)]
+        merge_layers = [("project", project_servers), ("global", global_servers), ("home", home_servers)]
     else:
-        merge_layers = [("home", home_servers), ("project", project_servers)]
+        merge_layers = [("global", global_servers), ("home", home_servers), ("project", project_servers)]
 
     for src_name, layer in merge_layers:
         for name, cfg in layer.items():
@@ -412,9 +455,9 @@ def load_servers_merged(
 
 def tokens_path(*, script_file: Optional[str] = None) -> Optional[Path]:
     ica_home = get_ica_home(script_file=script_file)
-    if not ica_home:
-        return None
-    return ica_home / "mcp-tokens.json"
+    if ica_home:
+        return ica_home / "mcp-tokens.json"
+    return get_ica_global_root() / "mcp-tokens.json"
 
 
 def load_tokens(*, script_file: Optional[str] = None) -> dict:
@@ -436,7 +479,7 @@ def load_tokens(*, script_file: Optional[str] = None) -> dict:
 def save_tokens(data: dict, *, script_file: Optional[str] = None) -> None:
     path = tokens_path(script_file=script_file)
     if not path:
-        raise ValueError("ICA_HOME is required to store tokens (set ICA_HOME or install into an agent home).")
+        raise ValueError("Unable to resolve an ICA token path.")
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
     fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_cli.py
@@ -15,7 +15,7 @@ Commands:
 
 Notes:
   - Trust commands are used with ICA_MCP_STRICT_TRUST=1.
-  - `trust` stores trust in $ICA_HOME/mcp-trust.json (or ICA_MCP_TRUST_PATH).
+  - `trust` stores trust in the active agent home when available, otherwise $ICA_STATE_HOME/mcp-trust.json (or ICA_MCP_TRUST_PATH).
 """
 
 from __future__ import annotations

--- a/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
+++ b/src/skills/mcp-proxy/scripts/mcp_proxy_server.py
@@ -3,10 +3,10 @@
 ICA MCP Proxy Server (stdio)
 
 Implements a local MCP server that:
-- loads upstream MCP servers from .mcp.json and/or $ICA_HOME/mcp-servers.json
+- loads upstream MCP servers from .mcp.json, shared ICA global config, and the active agent-home override
 - mirrors upstream tools as proxy tools: "<server>.<tool>"
 - provides stable broker tools under "proxy.*"
-- manages OAuth + token caching in $ICA_HOME/mcp-tokens.json
+- manages OAuth + token caching in the active agent home when available, otherwise shared ICA global state
 """
 
 from __future__ import annotations
@@ -565,7 +565,7 @@ def _broker_tool_defs():
     return [
         types.Tool(
             name="proxy.list_servers",
-            description="List configured upstream MCP servers (merged from .mcp.json and $ICA_HOME/mcp-servers.json).",
+            description="List configured upstream MCP servers (merged from project, shared ICA global, and active agent-home MCP config).",
             inputSchema=obj,
         ),
         types.Tool(

--- a/src/targets/claude/hooks/agent-infrastructure-protection.js
+++ b/src/targets/claude/hooks/agent-infrastructure-protection.js
@@ -891,7 +891,7 @@ WORKFLOW:
 To allow imperative commands: Set enforcement.blocking_enabled=false in ica.config.json
 Emergency override: EMERGENCY_OVERRIDE:<token> <command>
 
-Configuration: ./ica.config.json or ./.claude/ica.config.json`
+Configuration: ./.ica/config.json, ~/.ica/ica.config.json, or the active agent-home override`
           }));
           process.exit(0);
         } else {
@@ -957,7 +957,7 @@ To allow this operation:
 2. Add to whitelist: enforcement.infrastructure_protection.whitelist
 3. Or disable protection: enforcement.infrastructure_protection.enabled: false
 
-Configuration: ./ica.config.json or ./.claude/ica.config.json`
+Configuration: ./.ica/config.json, ~/.ica/ica.config.json, or the active agent-home override`
         }));
         process.exit(0);
       }
@@ -991,7 +991,7 @@ To allow read operations:
 1. Enable in configuration: enforcement.infrastructure_protection.read_operations_allowed: true
 2. Or add to whitelist: enforcement.infrastructure_protection.whitelist
 
-Configuration: ./ica.config.json or ./.claude/ica.config.json`
+Configuration: ./.ica/config.json, ~/.ica/ica.config.json, or the active agent-home override`
           }));
           process.exit(0);
         }

--- a/src/targets/claude/hooks/lib/config-loader.js
+++ b/src/targets/claude/hooks/lib/config-loader.js
@@ -3,7 +3,7 @@
 /**
  * Unified Configuration Loader for Intelligent Code Agents
  *
- * Hierarchy: ./ica.config.json → $ICA_HOME/ica.config.json → ica.config.default.json
+ * Hierarchy: ./.ica/config.json → <active-agent-home>/ica.config.json → ~/.ica/ica.config.json → ica.config.default.json
  * Backward compatibility: Falls back to CLAUDE.md/config.md if ica.config.json missing (Claude Code integration)
  * 5-minute TTL cache for performance
  */
@@ -12,10 +12,48 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-function getAgentHomeDir() {
-  // Allow non-Claude tools to reuse these hooks/libs by setting ICA_HOME.
-  // Default remains Claude Code's directory for backward compatibility.
-  return process.env.ICA_HOME || path.join(os.homedir(), '.claude');
+const ACTIVE_TARGET_HOME_DIRS = {
+  claude: '.claude',
+  codex: '.codex',
+  cursor: '.cursor',
+  gemini: '.gemini',
+  antigravity: path.join('.gemini', 'antigravity')
+};
+
+function getIcaGlobalRoot() {
+  return path.resolve(process.env.ICA_STATE_HOME || process.env.ICA_GLOBAL_HOME || path.join(os.homedir(), '.ica'));
+}
+
+function inferInstalledAgentHome() {
+  const candidates = [
+    path.resolve(__dirname, '../..'),
+    path.resolve(__dirname, '../../..'),
+    path.resolve(__dirname, '../../../..')
+  ];
+
+  for (const candidate of candidates) {
+    if (path.basename(candidate) === 'src') {
+      continue;
+    }
+    if (fs.existsSync(path.join(candidate, 'VERSION')) && !fs.existsSync(path.join(candidate, 'targets'))) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function getActiveAgentHomeDir() {
+  if (process.env.ICA_HOME) {
+    return path.resolve(process.env.ICA_HOME);
+  }
+
+  const activeTarget = (process.env.ICA_ACTIVE_TARGET || '').trim().toLowerCase();
+  if (activeTarget && ACTIVE_TARGET_HOME_DIRS[activeTarget]) {
+    return path.resolve(os.homedir(), ACTIVE_TARGET_HOME_DIRS[activeTarget]);
+  }
+
+  return inferInstalledAgentHome();
 }
 
 const PROJECT_AGENT_DIRS = [
@@ -201,7 +239,7 @@ function parseValue(value) {
 /**
  * Find configuration file in priority order
  */
-function findConfigFile(projectRoot, filename) {
+function findProjectConfigFile(projectRoot, filename) {
   const baseFilename = filename.replace('ica.', '');
   const searchPaths = [
     path.join(projectRoot, '.ica', baseFilename),      // .ica/config.json
@@ -216,6 +254,11 @@ function findConfigFile(projectRoot, filename) {
   }
 
   return null;
+}
+
+function loadUserLayer(rootPath, filename) {
+  if (!rootPath) return null;
+  return loadJsonConfig(path.join(rootPath, filename));
 }
 
 /**
@@ -247,17 +290,22 @@ function loadWorkflowConfig() {
     workflowConfig = {};
   }
 
-  // 2. Try to load user global workflow configuration
-  const userWorkflowPath = findConfigFile(getAgentHomeDir(), 'ica.workflow.json');
-  if (userWorkflowPath) {
-    const userWorkflow = loadJsonConfig(userWorkflowPath);
-    if (userWorkflow) {
-      workflowConfig = deepMerge(workflowConfig, userWorkflow);
+  // 2. Load shared ICA workflow, then active agent-home override.
+  const globalWorkflow = loadUserLayer(getIcaGlobalRoot(), 'ica.workflow.json');
+  if (globalWorkflow) {
+    workflowConfig = deepMerge(workflowConfig, globalWorkflow);
+  }
+
+  const activeAgentHome = getActiveAgentHomeDir();
+  if (activeAgentHome && path.resolve(activeAgentHome) !== path.resolve(getIcaGlobalRoot())) {
+    const activeWorkflow = loadUserLayer(activeAgentHome, 'ica.workflow.json');
+    if (activeWorkflow) {
+      workflowConfig = deepMerge(workflowConfig, activeWorkflow);
     }
   }
 
   // 3. Try to load project workflow configuration
-  const projectWorkflowPath = findConfigFile(process.cwd(), 'ica.workflow.json');
+  const projectWorkflowPath = findProjectConfigFile(process.cwd(), 'ica.workflow.json');
   if (projectWorkflowPath) {
     const projectWorkflow = loadJsonConfig(projectWorkflowPath);
     if (projectWorkflow) {
@@ -304,18 +352,25 @@ function loadConfig() {
     config = getHardcodedDefaults();
   }
 
-  // 2. Try to load user global configuration
-  const userConfigPath = findConfigFile(getAgentHomeDir(), 'ica.config.json');
+  // 2. Load shared ICA config, then active agent-home override.
   let userConfig = null;
-  if (userConfigPath) {
-    userConfig = loadJsonConfig(userConfigPath);
-    if (userConfig) {
-      config = deepMerge(config, userConfig);
+  const globalUserConfig = loadUserLayer(getIcaGlobalRoot(), 'ica.config.json');
+  if (globalUserConfig) {
+    userConfig = globalUserConfig;
+    config = deepMerge(config, globalUserConfig);
+  }
+
+  const activeAgentHome = getActiveAgentHomeDir();
+  if (activeAgentHome && path.resolve(activeAgentHome) !== path.resolve(getIcaGlobalRoot())) {
+    const agentUserConfig = loadUserLayer(activeAgentHome, 'ica.config.json');
+    if (agentUserConfig) {
+      userConfig = deepMerge(userConfig || {}, agentUserConfig);
+      config = deepMerge(config, agentUserConfig);
     }
   }
 
   // 3. Try to load project configuration
-  const projectConfigPath = findConfigFile(process.cwd(), 'ica.config.json');
+  const projectConfigPath = findProjectConfigFile(process.cwd(), 'ica.config.json');
   let projectConfig = null;
   if (projectConfigPath) {
     projectConfig = loadJsonConfig(projectConfigPath);
@@ -426,5 +481,7 @@ function clearCache() {
 module.exports = {
   loadConfig,
   getSetting,
-  clearCache
+  clearCache,
+  getActiveAgentHomeDir,
+  getIcaGlobalRoot
 };

--- a/tests/hooks/unit/test-config-loader.js
+++ b/tests/hooks/unit/test-config-loader.js
@@ -5,12 +5,53 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { runTestSuite } = require('../fixtures/test-helpers');
 const {
   loadConfig,
   getSetting,
-  clearCache
+  clearCache,
+  getActiveAgentHomeDir,
+  getIcaGlobalRoot
 } = require('../../../src/targets/claude/hooks/lib/config-loader.js');
+
+function withTempEnv(callback) {
+  const previous = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    ICA_HOME: process.env.ICA_HOME,
+    ICA_STATE_HOME: process.env.ICA_STATE_HOME,
+    ICA_GLOBAL_HOME: process.env.ICA_GLOBAL_HOME,
+    ICA_ACTIVE_TARGET: process.env.ICA_ACTIVE_TARGET
+  };
+  const previousCwd = process.cwd();
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ica-config-loader-'));
+  const tempProject = fs.mkdtempSync(path.join(os.tmpdir(), 'ica-config-loader-project-'));
+
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.ICA_STATE_HOME = path.join(tempHome, '.ica');
+  delete process.env.ICA_HOME;
+  delete process.env.ICA_GLOBAL_HOME;
+  delete process.env.ICA_ACTIVE_TARGET;
+  process.chdir(tempProject);
+
+  try {
+    return callback({ tempHome, tempProject });
+  } finally {
+    process.chdir(previousCwd);
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    clearCache();
+  }
+}
 
 const tests = {
   'loadConfig: returns configuration object': () => {
@@ -106,6 +147,42 @@ const tests = {
 
     assert.ok(typeof result === 'string', 'Should be string');
     assert.ok(result.length > 0, 'Should not be empty');
+  },
+
+  'loadConfig: active agent-home override wins over shared ICA global config': () => {
+    withTempEnv(({ tempHome }) => {
+      const globalRoot = path.join(tempHome, '.ica');
+      const agentHome = path.join(tempHome, '.codex');
+      fs.mkdirSync(globalRoot, { recursive: true });
+      fs.mkdirSync(agentHome, { recursive: true });
+      fs.writeFileSync(path.join(globalRoot, 'ica.config.json'), JSON.stringify({ git: { privacy: false } }), 'utf8');
+      fs.writeFileSync(path.join(agentHome, 'ica.config.json'), JSON.stringify({ git: { privacy: true } }), 'utf8');
+      process.env.ICA_HOME = agentHome;
+
+      clearCache();
+      const config = loadConfig();
+
+      assert.strictEqual(config.git.privacy, true);
+      assert.strictEqual(getActiveAgentHomeDir(), path.resolve(agentHome));
+      assert.strictEqual(getIcaGlobalRoot(), path.resolve(globalRoot));
+    });
+  },
+
+  'loadConfig: shared ICA global config is used when no active agent-home context exists': () => {
+    withTempEnv(({ tempHome }) => {
+      const globalRoot = path.join(tempHome, '.ica');
+      const codexHome = path.join(tempHome, '.codex');
+      fs.mkdirSync(globalRoot, { recursive: true });
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(path.join(globalRoot, 'ica.config.json'), JSON.stringify({ git: { privacy: false } }), 'utf8');
+      fs.writeFileSync(path.join(codexHome, 'ica.config.json'), JSON.stringify({ git: { privacy: true } }), 'utf8');
+
+      clearCache();
+      const config = loadConfig();
+
+      assert.strictEqual(config.git.privacy, false);
+      assert.strictEqual(getActiveAgentHomeDir(), null);
+    });
   }
 };
 

--- a/tests/installer/executor.test.ts
+++ b/tests/installer/executor.test.ts
@@ -163,6 +163,108 @@ test("symlink mode records effective mode", async () => {
   }
 });
 
+test("user scope install seeds shared ~/.ica config and workflow without creating target-home config", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-user-home-"));
+  const restoreHome = (() => {
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    return () => {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      if (previousUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = previousUserProfile;
+      }
+    };
+  })();
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = path.join(tempHome, ".ica");
+
+  try {
+    const report = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["codex"],
+      scope: "user",
+      mode: "copy",
+      skills: [],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(report.targets[0].errors.length, 0);
+    assert.ok(fs.existsSync(path.join(tempHome, ".ica", "ica.config.json")));
+    assert.ok(fs.existsSync(path.join(tempHome, ".ica", "ica.workflow.json")));
+    assert.equal(fs.existsSync(path.join(tempHome, ".codex", "ica.config.json")), false);
+  } finally {
+    restoreHome();
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
+test("user scope install migrates a single legacy agent-home config into shared ~/.ica", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-user-migrate-"));
+  const restoreHome = (() => {
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    return () => {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      if (previousUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = previousUserProfile;
+      }
+    };
+  })();
+  const previous = process.env.ICA_STATE_HOME;
+  process.env.ICA_STATE_HOME = path.join(tempHome, ".ica");
+
+  try {
+    fs.mkdirSync(path.join(tempHome, ".codex"), { recursive: true });
+    fs.writeFileSync(path.join(tempHome, ".codex", "ica.config.json"), JSON.stringify({ git: { privacy: false } }), "utf8");
+
+    const report = await executeOperation(repoRoot, {
+      operation: "install",
+      targets: ["codex"],
+      scope: "user",
+      mode: "copy",
+      skills: [],
+      removeUnselected: false,
+      installClaudeIntegration: false,
+    });
+
+    assert.equal(report.targets[0].errors.length, 0);
+    assert.ok(report.targets[0].warnings.some((warning) => warning.code === "GLOBAL_CONFIG_MIGRATED"));
+    const migrated = JSON.parse(fs.readFileSync(path.join(tempHome, ".ica", "ica.config.json"), "utf8")) as {
+      git?: { privacy?: boolean };
+    };
+    assert.equal(migrated.git?.privacy, false);
+    assert.ok(fs.existsSync(path.join(tempHome, ".codex", "ica.config.json")));
+  } finally {
+    restoreHome();
+    if (previous === undefined) {
+      delete process.env.ICA_STATE_HOME;
+    } else {
+      process.env.ICA_STATE_HOME = previous;
+    }
+  }
+});
+
 test("install fails when skill content digest changes after catalog load", async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ica-installer-test-"));
   const { sourceId, tempStateRoot } = await setupExternalSkillsSource("digest-mismatch");

--- a/tests/installer/tracking-config.test.ts
+++ b/tests/installer/tracking-config.test.ts
@@ -17,6 +17,7 @@ function createDeps(existingPaths: string[]): TrackingConfigDependencies {
   return {
     cwd: path.resolve("/workspace/project"),
     icaHome: path.resolve("/workspace/home/.ica"),
+    activeAgentHome: path.resolve("/workspace/home/.codex"),
     homeDir: path.resolve("/workspace/home"),
     pathExists: async (targetPath: string) => normalized.has(path.resolve(targetPath)),
     readText: async () => "",
@@ -32,6 +33,7 @@ function createDepsWithContents(contents: Record<string, string>): TrackingConfi
   return {
     cwd: path.resolve("/workspace/project"),
     icaHome: path.resolve("/workspace/home/.ica"),
+    activeAgentHome: path.resolve("/workspace/home/.codex"),
     homeDir: path.resolve("/workspace/home"),
     pathExists: async (targetPath: string) => normalizedContents.has(path.resolve(targetPath)),
     readText: async (targetPath: string) => normalizedContents.get(path.resolve(targetPath)) || "",
@@ -53,6 +55,7 @@ function createEnsureDeps(
   const deps: EnsureTrackingConfigDependencies = {
     cwd: path.resolve("/workspace/project"),
     icaHome: path.resolve("/workspace/home/.ica"),
+    activeAgentHome: path.resolve("/workspace/home/.codex"),
     homeDir: path.resolve("/workspace/home"),
     pathExists: async (targetPath: string) => normalizedContents.has(path.resolve(targetPath)),
     readText: async (targetPath: string) => normalizedContents.get(path.resolve(targetPath)) || "",
@@ -105,10 +108,10 @@ test("resolveTrackingConfig defaults fallback provider to file-based when github
   assert.equal(result.fallbackProvider as TrackingProvider, "file-based");
 });
 
-test("resolveTrackingConfig checks codex then claude agent-home fallbacks", async () => {
+test("resolveTrackingConfig uses the active agent-home override before shared global config", async () => {
   const codexConfig = path.join("/workspace/home", ".codex", "tracking.config.json");
-  const claudeConfig = path.join("/workspace/home", ".claude", "tracking.config.json");
-  const deps = createDeps([codexConfig, claudeConfig]);
+  const systemConfig = path.join("/workspace/home", ".ica", "tracking.config.json");
+  const deps = createDeps([codexConfig, systemConfig]);
   const result = await resolveTrackingConfig(deps);
 
   assert.equal(result.source, "agent-home");
@@ -150,16 +153,19 @@ test("resolveTrackingConfig emits diagnostics when selected config JSON is inval
   assert.ok(result.diagnostics.some((line: string) => line.includes("Invalid JSON")));
 });
 
-test("resolveTrackingConfig tolerates unset ICA_HOME and still checks agent-home candidates", async () => {
+test("resolveTrackingConfig ignores inactive agent homes when no active agent context is available", async () => {
   const claudeConfig = path.join(os.homedir(), ".claude", "tracking.config.json");
   const deps = createDeps([claudeConfig]);
-  deps.icaHome = undefined;
+  deps.icaHome = path.join(os.homedir(), ".ica");
+  deps.activeAgentHome = undefined;
   deps.homeDir = os.homedir();
-  deps.pathExists = async (targetPath: string) => path.resolve(targetPath) === path.resolve(claudeConfig);
+  deps.pathExists = async (targetPath: string) =>
+    path.resolve(targetPath) === path.resolve(claudeConfig) ||
+    path.resolve(targetPath) === path.resolve(path.join(os.homedir(), ".ica", "tracking.config.json"));
 
   const result = await resolveTrackingConfig(deps);
-  assert.equal(result.path, claudeConfig);
-  assert.equal(result.source, "agent-home");
+  assert.equal(result.path, path.join(os.homedir(), ".ica", "tracking.config.json"));
+  assert.equal(result.source, "system");
 });
 
 test("ensureTrackingConfig asks scope and creates project config when user opts out of existing system config", async () => {

--- a/tests/mcp_proxy/test_proxy.py
+++ b/tests/mcp_proxy/test_proxy.py
@@ -141,6 +141,115 @@ class TestMcpProxy(unittest.TestCase):
                 else:
                     os.environ["ICA_HOME"] = old_ica_home
 
+    def test_global_mcp_config_is_used_without_active_agent_context(self):
+        ica_mcp_core = _load_core()
+
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            proj = td / "project"
+            proj.mkdir()
+            global_root = td / "ica-global"
+            global_root.mkdir()
+            codex_home = td / "codex-home"
+            codex_home.mkdir()
+
+            (global_root / "mcp-servers.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "shared": {"command": "python", "args": ["-c", "print('global')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (codex_home / "mcp-servers.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "shared": {"command": "python", "args": ["-c", "print('codex')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            old_state_home = os.environ.get("ICA_STATE_HOME")
+            old_ica_home = os.environ.get("ICA_HOME")
+            old_active_target = os.environ.get("ICA_ACTIVE_TARGET")
+            os.environ["ICA_STATE_HOME"] = str(global_root)
+            os.environ.pop("ICA_HOME", None)
+            os.environ.pop("ICA_ACTIVE_TARGET", None)
+            try:
+                loaded = ica_mcp_core.load_servers_merged(script_file=None, cwd=proj)  # type: ignore[arg-type]
+            finally:
+                if old_state_home is None:
+                    del os.environ["ICA_STATE_HOME"]
+                else:
+                    os.environ["ICA_STATE_HOME"] = old_state_home
+                if old_ica_home is None:
+                    os.environ.pop("ICA_HOME", None)
+                else:
+                    os.environ["ICA_HOME"] = old_ica_home
+                if old_active_target is None:
+                    os.environ.pop("ICA_ACTIVE_TARGET", None)
+                else:
+                    os.environ["ICA_ACTIVE_TARGET"] = old_active_target
+
+            self.assertEqual(loaded.servers["shared"]["args"][-1], "print('global')")
+
+    def test_active_agent_home_overrides_shared_global_mcp_config(self):
+        ica_mcp_core = _load_core()
+
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            proj = td / "project"
+            proj.mkdir()
+            global_root = td / "ica-global"
+            global_root.mkdir()
+            ica_home = td / "ica-home"
+            ica_home.mkdir()
+            (ica_home / "VERSION").write_text("test", encoding="utf-8")
+
+            (global_root / "mcp-servers.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "shared": {"command": "python", "args": ["-c", "print('global')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (ica_home / "mcp-servers.json").write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "shared": {"command": "python", "args": ["-c", "print('home')"]},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            old_state_home = os.environ.get("ICA_STATE_HOME")
+            old_ica_home = os.environ.get("ICA_HOME")
+            os.environ["ICA_STATE_HOME"] = str(global_root)
+            os.environ["ICA_HOME"] = str(ica_home)
+            try:
+                loaded = ica_mcp_core.load_servers_merged(script_file=None, cwd=proj)  # type: ignore[arg-type]
+            finally:
+                if old_state_home is None:
+                    del os.environ["ICA_STATE_HOME"]
+                else:
+                    os.environ["ICA_STATE_HOME"] = old_state_home
+                if old_ica_home is None:
+                    del os.environ["ICA_HOME"]
+                else:
+                    os.environ["ICA_HOME"] = old_ica_home
+
+            self.assertEqual(loaded.servers["shared"]["args"][-1], "print('home')")
+
     def test_proxy_mirrors_and_calls(self):
         import anyio
         from mcp import StdioServerParameters


### PR DESCRIPTION
## Summary
- make `~/.ica` the canonical shared ICA config/state root
- keep the active agent home as an override instead of a global default
- update installer, loader, MCP, docs, and regression coverage to match

## Changes
- add shared runtime path helpers for `ICA_STATE_HOME` and active agent-home resolution
- seed and migrate shared user config/workflow into `~/.ica` during user-scope installs
- stop broad `.codex`/`.claude` fallback in config and tracking resolution
- make MCP config/token/trust resolution prefer shared global state with active agent-home override
- add tests for shared-global vs active-agent precedence and installer migration behavior

## Test Plan
- [x] `npm run build:quick`
- [x] `node tests/hooks/unit/test-config-loader.js`
- [x] `node --test dist/tests/installer/tracking-config.test.js dist/tests/installer/executor.test.js`
- [x] `python3 -m unittest tests.mcp_proxy.test_proxy`

## Notes
- `npm audit --omit=dev --audit-level=high` reports existing dependency vulnerabilities in upstream dependencies; this PR does not change dependency versions.